### PR TITLE
Support nested branch names (e.g., feature/foo)

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -14,7 +14,7 @@
       "author": {
         "name": "sestinj"
       },
-      "source": ".",
+      "source": "./",
       "category": "productivity",
       "tags": ["git", "version-control", "code-review", "conversations"],
       "homepage": "https://github.com/sestinj/tin"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://anthropic.com/claude-code/marketplace.schema.json",
+  "name": "tin-marketplace",
+  "description": "Thread-based version control for conversational coding. Links AI conversation threads to git commits for code review context.",
+  "owner": {
+    "name": "sestinj",
+    "url": "https://github.com/sestinj/tin"
+  },
+  "plugins": [
+    {
+      "name": "tin",
+      "description": "Thread-based version control for conversational coding. Wraps git to link AI conversation threads to commits, giving PR reviewers full context on why changes were made.",
+      "version": "1.0.0",
+      "author": {
+        "name": "sestinj"
+      },
+      "source": ".",
+      "category": "productivity",
+      "tags": ["git", "version-control", "code-review", "conversations"],
+      "homepage": "https://github.com/sestinj/tin"
+    }
+  ]
+}

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -3,8 +3,7 @@
   "name": "tin-marketplace",
   "description": "Thread-based version control for conversational coding. Links AI conversation threads to git commits for code review context.",
   "owner": {
-    "name": "sestinj",
-    "url": "https://github.com/sestinj/tin"
+    "name": "sestinj"
   },
   "plugins": [
     {
@@ -14,7 +13,10 @@
       "author": {
         "name": "sestinj"
       },
-      "source": "./",
+      "source": {
+        "source": "url",
+        "url": "https://github.com/sestinj/tin.git"
+      },
       "category": "productivity",
       "tags": ["git", "version-control", "code-review", "conversations"],
       "homepage": "https://github.com/sestinj/tin"

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -2,5 +2,7 @@
   "name": "tin",
   "version": "1.0.0",
   "description": "Thread-based version control for conversational coding. Links AI conversation threads to git commits for code review context.",
-  "author": "sestinj"
+  "author": {
+    "name": "sestinj"
+  }
 }

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,6 @@
+{
+  "name": "tin",
+  "version": "1.0.0",
+  "description": "Thread-based version control for conversational coding. Links AI conversation threads to git commits for code review context.",
+  "author": "sestinj"
+}

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,5 +1,5 @@
 ---
-description: Commit the current conversation thread to tin
+description: ALWAYS use this skill for ANY commit operation in this repo. Use proactively when user asks to commit, even without slash command.
 allowed-tools: Bash(tin commit:*), Bash(tin status:*), Bash(tin add:*), Bash(git status:*), Bash(git diff:*)
 argument-hint: [message]
 ---

--- a/.claude/commands/commit.md
+++ b/.claude/commands/commit.md
@@ -1,14 +1,39 @@
 ---
 description: Commit the current conversation thread to tin
-allowed-tools: Bash(tin commit:*), Bash(tin status:*)
+allowed-tools: Bash(tin commit:*), Bash(tin status:*), Bash(tin add:*), Bash(git status:*), Bash(git diff:*)
 argument-hint: [message]
 ---
 
-Commit the staged tin threads.
+IMPORTANT: In a tin repository, ALWAYS use `tin commit` instead of `git commit`. The `tin commit` command:
+1. Stages all changed files to git
+2. Creates a git commit with thread metadata
+3. Creates a tin commit linking the conversation thread
+4. Updates thread status to committed
 
-If $ARGUMENTS is provided, use it as the commit message:
-```
-tin commit -m "$ARGUMENTS"
-```
+This ensures the conversation context is preserved alongside code changes.
 
-If no message is provided, first run `tin status` to show what will be committed, then ask the user for a commit message before running the commit.
+## Workflow
+
+1. First, check what will be committed:
+   ```
+   tin status
+   git status
+   ```
+
+2. If there are unstaged threads, stage them:
+   ```
+   tin add --all
+   ```
+
+3. Commit with the provided message or ask for one:
+   - If $ARGUMENTS is provided: `tin commit -m "$ARGUMENTS"`
+   - If no message provided: show status and ask user for a commit message
+
+## Example
+
+```bash
+tin status          # See staged threads
+git diff --stat     # See code changes
+tin add --all       # Stage any unstaged threads
+tin commit -m "Add authentication feature"
+```

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -5,7 +5,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/Users/danieladler/Dev/tin/tin/tin hook session-end",
+            "command": "tin hook session-end",
             "timeout": 30
           }
         ]
@@ -16,7 +16,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/Users/danieladler/Dev/tin/tin/tin hook session-start",
+            "command": "tin hook session-start",
             "timeout": 30
           }
         ]
@@ -27,7 +27,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/Users/danieladler/Dev/tin/tin/tin hook stop",
+            "command": "tin hook stop",
             "timeout": 30
           }
         ]
@@ -38,7 +38,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "/Users/danieladler/Dev/tin/tin/tin hook user-prompt",
+            "command": "tin hook user-prompt",
             "timeout": 30
           }
         ]

--- a/.cursor/hooks.json
+++ b/.cursor/hooks.json
@@ -1,0 +1,20 @@
+{
+  "version": 1,
+  "hooks": {
+    "afterFileEdit": [
+      {
+        "command": "/Users/nate/go/bin/tin hook cursor-file-edit"
+      }
+    ],
+    "beforeSubmitPrompt": [
+      {
+        "command": "/Users/nate/go/bin/tin hook cursor-prompt"
+      }
+    ],
+    "stop": [
+      {
+        "command": "/Users/nate/go/bin/tin hook cursor-stop"
+      }
+    ]
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
-tin
-.tin/
+/tin
 .DS_Store
+
+# Tin - ignore thread data, but track config for team
+.tin/*
+!.tin/config

--- a/.tin/config
+++ b/.tin/config
@@ -7,5 +7,5 @@
     }
   ],
   "code_host_url": "https://github.com/sestinj/tin",
-  "thread_host_url": "http://52.90.157.114:8000"
+  "thread_host_url": "https://tinhub.exe.xyz:8000/sestinj/tin"
 }

--- a/.tin/config
+++ b/.tin/config
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "remotes": [
+    {
+      "name": "origin",
+      "url": "52.90.157.114:2323/sestinj/tin.tin"
+    }
+  ],
+  "code_host_url": "https://github.com/sestinj/tin",
+  "thread_host_url": "http://52.90.157.114:8000"
+}

--- a/.tin/config
+++ b/.tin/config
@@ -3,7 +3,7 @@
   "remotes": [
     {
       "name": "origin",
-      "url": "52.90.157.114:2323/sestinj/tin.tin"
+      "url": "https://tinhub.exe.xyz:8443/sestinj/tin"
     }
   ],
   "code_host_url": "https://github.com/sestinj/tin",

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -76,3 +76,7 @@ Threads are deduplicated by Amp thread ID (stored in `AgentSessionID`).
 ```bash
 go build -o tin ./cmd/tin
 ```
+
+## Feedback: Test Driving Tin
+
+We are test driving `tin`, which means it is really important to collect feedback on how it works in real-world situations, and whether the workflow is ergonomic. If you ever come across small bugs, workflow issues, awkward details, or even just situations where the mental model doesn't make sense or you are running too many commands repeatedly, log these observations in a file called `OBSERVATIONS.md`. It should be a markdown file, section-separated by `---` between each observation. The observations should be concise descriptions of what was noticed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,23 +4,13 @@ Thread-based version control for conversational coding. Wraps git, treating conv
 
 ## Important: Use Tin Commands
 
-**Always use built-in tin commands instead of git commands or directly modifying `.tin/` storage on disk.**
-
-### Committing: Use `tin commit`, NOT `git commit`
-
-When committing changes in a tin repository, **always use `tin commit`** (or the `/commit` slash command). The `tin commit` command:
-1. Automatically stages all changed files to git
-2. Creates a git commit with thread metadata in the message
-3. Creates a tin commit linking the conversation thread to the code
-4. Updates the thread status
-
-Using `git commit` directly will lose the thread context and break the tin workflow.
-
-### Other examples:
+**Always use built-in tin commands instead of directly modifying `.tin/` storage on disk.** For example:
 - Use `tin thread delete` instead of `rm .tin/threads/<id>.json`
 - Use `tin add --unstage` instead of editing `.tin/index.json`
 
 Direct file manipulation can leave the repository in an inconsistent state (e.g., orphaned staging entries, missing index updates).
+
+**Note for tin developers:** Do not add tin usage instructions (like "use tin commit instead of git commit") to this CLAUDE.md. The tin workflow should work for normal users via hooks and skills without needing special instructions in their project's CLAUDE.md.
 
 ## Quick Reference
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,15 @@
 
 Thread-based version control for conversational coding. Wraps git, treating conversation threads as the primary unit of change.
 
+## Design Principle: Follow Git
+
+Tin follows git's design decisions wherever possible. When implementing a feature, first research how git handles it and mirror that approach unless there's a clear reason not to. This makes tin predictable for users familiar with git and ensures we benefit from git's battle-tested design choices.
+
+Examples:
+- Transport-layer auth (not in wire protocol) - like git
+- Credential storage in global config, not repo config - like git
+- Command structure (`tin remote add`, `tin push`, etc.) - like git
+
 ## Important: Use Tin Commands
 
 **Always use built-in tin commands instead of directly modifying `.tin/` storage on disk.** For example:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,19 @@ Thread-based version control for conversational coding. Wraps git, treating conv
 
 ## Important: Use Tin Commands
 
-**Always use built-in tin commands instead of directly modifying `.tin/` storage on disk.** For example:
+**Always use built-in tin commands instead of git commands or directly modifying `.tin/` storage on disk.**
+
+### Committing: Use `tin commit`, NOT `git commit`
+
+When committing changes in a tin repository, **always use `tin commit`** (or the `/commit` slash command). The `tin commit` command:
+1. Automatically stages all changed files to git
+2. Creates a git commit with thread metadata in the message
+3. Creates a tin commit linking the conversation thread to the code
+4. Updates the thread status
+
+Using `git commit` directly will lose the thread context and break the tin workflow.
+
+### Other examples:
 - Use `tin thread delete` instead of `rm .tin/threads/<id>.json`
 - Use `tin add --unstage` instead of editing `.tin/index.json`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -76,3 +76,7 @@ Threads are deduplicated by Amp thread ID (stored in `AgentSessionID`).
 ```bash
 go build -o tin ./cmd/tin
 ```
+
+## Feedback: Test Driving Tin
+
+We are test driving `tin`, which means it is really important to collect feedback on how it works in real-world situations, and whether the workflow is ergonomic. If you ever come across small bugs, workflow issues, awkward details, or even just situations where the mental model doesn't make sense or you are running too many commands repeatedly, log these observations in a file called `OBSERVATIONS.md`. It should be a markdown file, section-separated by `---` between each observation. The observations should be concise descriptions of what was noticed.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,4 +81,12 @@ go build -o tin ./cmd/tin
 
 ## Feedback: Test Driving Tin
 
-We are test driving `tin`, which means it is really important to collect feedback on how it works in real-world situations, and whether the workflow is ergonomic. If you ever come across small bugs, workflow issues, awkward details, or even just situations where the mental model doesn't make sense or you are running too many commands repeatedly, log these observations in a file called `OBSERVATIONS.md`. It should be a markdown file, section-separated by `---` between each observation. The observations should be concise descriptions of what was noticed.
+We are test driving `tin`, which means it is really important to collect feedback on how it works in real-world situations, and whether the workflow is ergonomic. Log observations to `OBSERVATIONS.md` whenever you encounter:
+
+- **Errors or missing commands** (e.g., `unknown subcommand` errors, missing flags)
+- **Workflow friction** (e.g., needing multiple commands for what should be one operation)
+- **Mental model mismatches** (e.g., behavior that doesn't match git conventions)
+- **Bugs or unexpected behavior**
+- **Awkward UX** (e.g., confusing output, missing help text)
+
+**Important:** Log observations immediately when encountered, don't wait until later. Use `---` to separate each observation. Be concise but include the actual error/command that triggered the observation.

--- a/OBSERVATIONS.md
+++ b/OBSERVATIONS.md
@@ -28,3 +28,16 @@ Possible solutions:
 - Create empty git commits for thread-only tin commits (with thread metadata in commit message)
 - Store thread references in a git-tracked manifest file
 - Accept this as intentional (threads without code changes are ephemeral)
+
+---
+
+**Missing `tin remote set-url` subcommand**
+
+When needing to change a remote URL (e.g., from `tinhub.dev` to an IP address), there's no `set-url` subcommand like git has. Had to remove and re-add the remote:
+
+```bash
+tin remote remove origin
+tin remote add origin 52.90.157.114:2323/sestinj/tin.tin
+```
+
+Expected: `tin remote set-url origin <new-url>` to match git's interface.

--- a/OBSERVATIONS.md
+++ b/OBSERVATIONS.md
@@ -1,0 +1,13 @@
+# Tin Observations
+
+Workflow issues, bugs, and ergonomic observations collected while test driving tin.
+
+---
+
+**Missing `--unstage` flag in CLI**
+
+When trying to commit only a specific thread (while others were staged), there was no way to unstage the other threads from the CLI. The `tin add --unstage` flag is mentioned in CLAUDE.md but isn't implemented - the `UnstageThread` function exists in the storage layer but isn't exposed as a command. Had to manually edit `.tin/index.json` to unstage threads, which the documentation explicitly warns against.
+
+Workaround: Edit `.tin/index.json` directly to remove unwanted staged threads.
+
+Expected: `tin add --unstage <thread-id>` or a separate `tin unstage <thread-id>` command.

--- a/OBSERVATIONS.md
+++ b/OBSERVATIONS.md
@@ -41,3 +41,35 @@ tin remote add origin 52.90.157.114:2323/sestinj/tin.tin
 ```
 
 Expected: `tin remote set-url origin <new-url>` to match git's interface.
+
+---
+
+**Credentials stored in version-controlled config file**
+
+The `.tin/config` file is tracked in git (via `!.tin/config` in .gitignore), but credentials are stored there too. This means `tin config credentials add` would commit secrets to the repo.
+
+Current workaround: Use `TIN_AUTH_TOKEN` environment variable instead.
+
+Expected: Either store credentials in a separate `.tin/credentials` file that's gitignored, or in a global `~/.tin/credentials` file outside the repo.
+
+**Update:** Fixed - credentials now stored globally in `~/.config/tin/credentials`.
+
+---
+
+**`tin push` assumes git and tin remote names match**
+
+`tin push <remote> <branch>` uses the same remote name for both git and tin. But git and tin remotes are independent - you might have:
+- git remote "origin" → github.com
+- tin remote "tinhub" → tinhub.exe.xyz
+
+Running `tin push tinhub main` fails because there's no git remote called "tinhub":
+
+```
+$ tin push tinhub main
+Pushing git to tinhub/main...
+error: git push failed: fatal: 'tinhub' does not appear to be a git repository
+```
+
+Workaround: Use matching names for git and tin remotes.
+
+Question: Should tin support separate git/tin remote names? e.g., `tin push --git-remote origin --tin-remote tinhub main`

--- a/OBSERVATIONS.md
+++ b/OBSERVATIONS.md
@@ -11,3 +11,20 @@ When trying to commit only a specific thread (while others were staged), there w
 Workaround: Edit `.tin/index.json` directly to remove unwanted staged threads.
 
 Expected: `tin add --unstage <thread-id>` or a separate `tin unstage <thread-id>` command.
+
+---
+
+**Conversational threads have no git history**
+
+When a thread is purely conversational (no code changes), `tin commit` creates a tin commit but no git commit. Multiple tin commits can point to the same git hash. This means:
+
+1. These threads are invisible in `git log` - only visible via `tin log`
+2. If `.tin/` isn't pushed or gets lost, there's no record these discussions happened
+3. The "tin wraps git" mental model breaks down - some tin history exists outside git
+
+This could be a problem for important design discussions, architectural decisions, or planning threads that don't directly produce code but are valuable context for understanding why code exists.
+
+Possible solutions:
+- Create empty git commits for thread-only tin commits (with thread metadata in commit message)
+- Store thread references in a git-tracked manifest file
+- Accept this as intentional (threads without code changes are ephemeral)

--- a/OBSERVATIONS.md
+++ b/OBSERVATIONS.md
@@ -73,3 +73,7 @@ error: git push failed: fatal: 'tinhub' does not appear to be a git repository
 Workaround: Use matching names for git and tin remotes.
 
 Question: Should tin support separate git/tin remote names? e.g., `tin push --git-remote origin --tin-remote tinhub main`
+
+---
+
+When I `tin commit` and then afterward ask a few follow up questions in those same sessions, it causes there to be unstaged threads that feel messy and aren't necessarily related to whatever next commit I make, but they will be bound to be committed along with the next set of changes

--- a/OBSERVATIONS.md
+++ b/OBSERVATIONS.md
@@ -77,3 +77,24 @@ Question: Should tin support separate git/tin remote names? e.g., `tin push --gi
 ---
 
 When I `tin commit` and then afterward ask a few follow up questions in those same sessions, it causes there to be unstaged threads that feel messy and aren't necessarily related to whatever next commit I make, but they will be bound to be committed along with the next set of changes
+
+---
+
+**Cross-repo work loses thread context**
+
+When working on multiple repos in a single Claude Code session, the conversation thread is tracked in whichever repo the session was started from. For example:
+
+- Session started in `sestinj/tinhub`
+- Made changes to `sestinj/tin` (credential prompting feature)
+- Ran `tin commit` in the tin repo
+- The commit linked to an *unrelated* thread from a previous tin session
+
+The actual conversation explaining *why* the credential prompting was implemented lives in tinhub's `.tin/` directory, not tin's. So the tin commit has no meaningful thread context.
+
+This is a fundamental issue with how tin tracks conversations at the directory level rather than following where work actually happens.
+
+Possible solutions:
+- Support importing/referencing threads from other repos
+- Allow specifying a thread ID manually during commit: `tin commit --thread <id-from-other-repo>`
+- A "cross-repo thread" concept that can be referenced from multiple repos
+- Accept this limitation and document it (current state)

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ You still get a normal git repo, but every commit now has a linked thread explai
 ## Quickstart
 
 ```bash
-go install github.com/dadlerj/tin/cmd/tin@latest
+go install github.com/sestinj/tin/cmd/tin@latest
 
 ######################
 # If using Amp
@@ -76,11 +76,33 @@ tin status                      # See pending threads
 tin commit -m "Added feature"   # Commit threads + code together
 ```
 
+## Claude Code Plugin
+
+Install the tin plugin for Claude Code to get:
+- **Auto-invoked skill**: Claude automatically uses `tin` instead of `git` for commits, checkouts, and pushes
+- **Slash commands**: `/tin:commit`, `/tin:branches`, `/tin:checkout`
+
+```bash
+# Install the plugin
+claude plugin add sestinj/tin
+
+# Or install from local clone
+git clone https://github.com/sestinj/tin.git
+claude plugin add ./tin
+```
+
+After installing the plugin, Claude will automatically:
+- Use `tin commit` instead of `git commit`
+- Use `tin checkout` instead of `git checkout`
+- Use `tin push` instead of `git push`
+
+This ensures all your commits are linked to conversation threads for code review context.
+
 ## The full `tin` workflow
 
 1. **Download and install `tin`, and initialize your repository**
 
-Run `go install github.com/dadlerj/tin/cmd/tin@latest`
+Run `go install github.com/sestinj/tin/cmd/tin@latest`
 
 Run `tin init` in your new project folder or existing git repo.
 

--- a/README.md
+++ b/README.md
@@ -132,9 +132,37 @@ See [all `tin` commands](COMMANDS.md).
 
 ### `tin` server and web viewer
 
-`tin` ships with a `tin serve` command that starts a remote server that can accept `tin push`es and `tin pull`s. Use `tin remote` to point to the remote server.
+`tin` ships with server commands for hosting remote repositories:
 
-`tin` also provides a simple web viewer to see tin repositories, commits, and threads. Run `tin serve --web --port 8080` to view it.
+```bash
+# TCP server (for local networks or trusted environments)
+tin serve --root ~/tin-repos                    # Serve repos on port 2323
+tin serve --root ~/tin-repos --host 0.0.0.0     # Listen on all interfaces
+
+# HTTP server with Basic Auth (for production)
+tin serve-http --root ~/tin-repos --auth admin:secrettoken
+tin serve-http --root ~/tin-repos --auth alice:pass1 --auth bob:pass2
+
+# Or configure auth via environment variable
+TIN_SERVER_AUTH=alice:pass1,bob:pass2 tin serve-http --root ~/tin-repos
+```
+
+Client setup:
+```bash
+# For TCP server
+tin remote add origin localhost:2323/myproject.tin
+tin push origin main
+
+# For HTTP server
+tin remote add origin https://host:8443/myproject.tin
+tin config credentials add host:8443 admin:secrettoken
+tin push origin main
+```
+
+`tin` also provides a simple web viewer to see repositories, commits, and threads:
+```bash
+tin serve --web --root ~/projects --port 8080
+```
 
 **The tin web commits page**
 

--- a/cmd/tin/main.go
+++ b/cmd/tin/main.go
@@ -43,8 +43,12 @@ func main() {
 		err = commands.Hooks(args)
 	case "amp":
 		err = commands.Amp(args)
+	case "codex":
+		err = commands.Codex(args)
+	case "agents":
+		err = commands.Agents(args)
 	case "hook":
-		// Internal hook handlers (called by Claude Code hooks)
+		// Internal hook handlers (called by AI agent hooks)
 		err = commands.Hooks(args)
 	case "remote":
 		err = commands.Remote(args)
@@ -56,6 +60,8 @@ func main() {
 		err = commands.Pull(args)
 	case "serve":
 		err = commands.Serve(args)
+	case "serve-http":
+		err = commands.ServeHTTP(args)
 	case "config":
 		err = commands.Config(args)
 	case "version", "--version", "-v":
@@ -88,15 +94,20 @@ Commands:
   commit      Record changes to the repository
   log         Show commit history with thread summaries
   thread      Manage threads (list, show, start, append)
-  hooks       Manage Claude Code integration hooks
-  amp         Manage Amp agent integration (pull threads)
   sync        Synchronize tin and git branch state
+
+Agent integrations:
+  hooks       Manage hooks for AI agents (Claude Code, Cursor)
+  agents      List and manage agent integrations
+  amp         Manage AMP agent integration (pull threads)
+  codex       Manage Codex CLI integration (notifications)
 
 Remote commands:
   remote      Manage remote repositories
   push        Push commits and threads to remote
   pull        Pull commits and threads from remote
-  serve       Start a tin server
+  serve       Start a tin server (TCP protocol)
+  serve-http  Start a tin HTTP server (HTTPS with Basic Auth)
   config      View and modify configuration
 
 Options:

--- a/commands/branches.md
+++ b/commands/branches.md
@@ -1,0 +1,6 @@
+---
+description: List all tin branches, marking the current one
+allowed-tools: Bash(tin branch:*)
+---
+
+Run `tin branch` and display the output to show all branches. The current branch is marked with *.

--- a/commands/checkout.md
+++ b/commands/checkout.md
@@ -1,0 +1,14 @@
+---
+description: Switch to a different tin branch
+allowed-tools: Bash(tin checkout:*), Bash(tin branch:*)
+argument-hint: [branch]
+---
+
+Switch to a different tin branch.
+
+If $ARGUMENTS is provided, checkout that branch:
+```
+tin checkout $ARGUMENTS
+```
+
+If no branch name is provided, first run `tin branch` to show available branches, then ask the user which branch to checkout.

--- a/commands/commit.md
+++ b/commands/commit.md
@@ -1,0 +1,14 @@
+---
+description: Commit the current conversation thread to tin
+allowed-tools: Bash(tin commit:*), Bash(tin status:*)
+argument-hint: [message]
+---
+
+Commit the staged tin threads.
+
+If $ARGUMENTS is provided, use it as the commit message:
+```
+tin commit -m "$ARGUMENTS"
+```
+
+If no message is provided, first run `tin status` to show what will be committed, then ask the user for a commit message before running the commit.

--- a/docs/AUTH_DESIGN.md
+++ b/docs/AUTH_DESIGN.md
@@ -1,200 +1,124 @@
-# TIN Authentication Design
+# TIN Authentication & Transport
 
-## Current State
+TIN supports multiple transports for remote operations, following Git's model where authentication is handled at the transport layer rather than embedded in the wire protocol.
 
-A temporary authentication mechanism was added directly to the TIN wire protocol, embedding an `auth` field in the `hello` message:
+## Transports
+
+### TCP Transport (Default)
+
+**URL formats:**
+- `tin://host:port/path`
+- `host:port/path`
+- `host/path` (default port 2323)
+
+Used for local networks or trusted environments. No built-in authentication.
+
+```bash
+tin remote add origin localhost:2323/myproject.tin
+tin push origin main
+```
+
+### HTTPS Transport
+
+**URL format:** `https://host/path`
+
+Uses HTTP Basic Auth for authentication. The TIN protocol messages are sent as POST request/response bodies.
+
+```bash
+tin remote add origin https://tinhub.dev/user/repo
+tin config credentials add tinhub.dev th_yourtoken
+tin push origin main
+```
+
+**HTTP Endpoints:**
+- `POST /{repo-path}/tin-receive-pack` - Push (client sends data)
+- `POST /{repo-path}/tin-upload-pack` - Pull (server sends data)
+- `POST /{repo-path}/tin-config` - Get/set repository config
+
+**Content-Type:** `application/x-tin-protocol`
+
+## Credential Storage
+
+Credentials are resolved in this order:
+
+1. **Environment variable** `TIN_AUTH_TOKEN` (highest priority)
+2. **Per-host credentials** in `.tin/config`
+3. **Legacy `auth_token`** in `.tin/config` (deprecated)
+
+### Managing Credentials
+
+```bash
+# Store credentials for a host
+tin config credentials add tinhub.dev th_xxxxx
+
+# List stored credentials
+tin config credentials
+
+# Remove credentials
+tin config credentials remove tinhub.dev
+```
+
+### Config File Format
 
 ```json
 {
-  "type": "hello",
-  "payload": {
-    "version": 1,
-    "operation": "push",
-    "repo_path": "/user/repo",
-    "auth": {
-      "type": "token",
-      "token": "th_xxxxx"
-    }
-  }
+  "version": 1,
+  "credentials": [
+    {"host": "tinhub.dev", "token": "th_xxxxx"},
+    {"host": "localhost:8443", "token": "th_yyyyy"}
+  ]
 }
 ```
 
-This works but **diverges from Git's design philosophy**. TIN's goal is to mirror Git's architecture closely, which makes design decisions simple and trustworthy.
+## Running an HTTP Server
 
-## How Git Handles Authentication
-
-Git does NOT embed authentication in its wire protocol. Instead, Git delegates authentication entirely to the transport layer:
-
-### SSH Transport (`git@github.com:user/repo.git`)
-- Authentication happens via SSH before Git ever speaks
-- User authenticates with SSH keys
-- The Git pack protocol has zero auth fields
-- SSH provides encryption, host verification, and auth in one layer
-
-### HTTPS Transport (`https://github.com/user/repo.git`)
-- Authentication via HTTP Basic Auth headers
-- Tokens (like GitHub PATs) are passed as the password
-- Git uses credential helpers to store/retrieve credentials
-- The Git pack protocol still has zero auth fields
-
-### Git Protocol (`git://host/repo.git`)
-- No authentication at all
-- Typically used for read-only public access
-- Rarely used for push operations
-
-## Proposed Design for TIN
-
-Following Git's model, TIN should support multiple transports with transport-layer authentication.
-
-### Option 1: SSH Transport
-
-**URL format:** `tin@tinhub.dev:user/repo` or `ssh://tin@tinhub.dev/user/repo`
-
-**How it works:**
-1. User has SSH key pair (~/.ssh/id_ed25519)
-2. User registers public key with TinHub (like GitHub SSH keys)
-3. `tin push` initiates SSH connection to tinhub.dev
-4. SSH authenticates user via key
-5. SSH spawns `tin-receive-pack` (or similar) on server
-6. TIN protocol flows over the authenticated SSH channel
-7. Server knows user identity from SSH auth
-
-**Server-side requirements:**
-- Run SSH server (or use Fly.io's SSH infrastructure)
-- Map SSH public keys to user accounts
-- Spawn TIN handler process for authenticated connections
-
-**Client-side changes:**
-- Add SSH transport in `internal/remote/`
-- Parse `tin@host:path` URL format
-- Use Go's `x/crypto/ssh` package
-- Remove `auth` field from protocol
-
-**Pros:**
-- Battle-tested authentication model
-- Users already have SSH keys
-- Encryption included
-- Exactly how Git does it
-
-**Cons:**
-- More complex server infrastructure
-- Need to manage SSH keys in TinHub
-
-### Option 2: HTTPS Transport
-
-**URL format:** `https://tinhub.dev/user/repo.tin`
-
-**How it works:**
-1. User has API token (th_xxxxx)
-2. `tin push` makes HTTPS request with `Authorization: Basic` header
-3. Username can be anything, password is the token
-4. Server validates token, identifies user
-5. TIN protocol flows over HTTPS (likely as POST body or WebSocket)
-
-**Server-side requirements:**
-- HTTPS endpoint that accepts TIN protocol
-- Validate Basic Auth credentials
-- Could use existing Hono API infrastructure
-
-**Client-side changes:**
-- Add HTTPS transport in `internal/remote/`
-- Implement credential helper system (like `git credential`)
-- Use standard HTTP client with Basic Auth
-- Remove `auth` field from protocol
-
-**Credential helper flow (matching Git):**
 ```bash
-# Git's credential helper protocol
-$ git credential fill
-protocol=https
-host=github.com
+# Start HTTP server
+tin serve-http --root /var/tin-repos
 
-# Helper responds with stored credentials
-protocol=https
-host=github.com
-username=user
-password=ghp_xxxx
+# With custom address
+tin serve-http --addr :8443 --root ~/tin-repos
 ```
 
-TIN could implement the same:
-```bash
-$ tin credential fill
-protocol=https
-host=tinhub.dev
+The server:
+- Requires HTTP Basic Auth (any username, token as password)
+- Auto-creates repositories on push
+- Uses the same protocol as TCP, just over HTTP
 
-# Response
-protocol=https
-host=tinhub.dev
-username=user
-password=th_xxxx
+For production, use a reverse proxy (nginx, caddy) for TLS termination.
+
+## Architecture
+
+```
+┌─────────────┐
+│   Client    │
+├─────────────┤
+│  Transport  │ ← TCP or HTTPS (selected by URL scheme)
+│  Interface  │
+└──────┬──────┘
+       │
+       ▼
+┌─────────────┐     ┌─────────────┐
+│    TCP      │     │   HTTPS     │
+│  Transport  │     │  Transport  │
+│             │     │ + Basic Auth│
+└──────┬──────┘     └──────┬──────┘
+       │                   │
+       ▼                   ▼
+   TCP Server         HTTP Server
+   (tin serve)      (tin serve-http)
 ```
 
-**Pros:**
-- Simpler server infrastructure (just HTTPS)
-- Works through corporate firewalls
-- Can reuse existing web infrastructure
+### Key Files
 
-**Cons:**
-- Need to implement credential helper system
-- Slightly more complex client code
+- `internal/remote/transport.go` - Transport interface
+- `internal/remote/tcp_transport.go` - TCP implementation
+- `internal/remote/https_transport.go` - HTTPS with Basic Auth
+- `internal/remote/credentials.go` - Credential store
+- `internal/remote/http_server.go` - HTTP server handler
 
-### Option 3: Both (Like Git)
+## Future Work
 
-Git supports both SSH and HTTPS. TIN could do the same:
-
-- `tin@tinhub.dev:user/repo` → SSH transport
-- `https://tinhub.dev/user/repo` → HTTPS transport
-- `tin://tinhub.dev/user/repo` → Unauthenticated TCP (read-only)
-
-## Recommendation
-
-**Start with SSH transport.** Reasons:
-
-1. **Simpler protocol** - No need for credential helpers initially
-2. **Users expect it** - Every Git user understands SSH keys
-3. **Security included** - Encryption and auth in one layer
-4. **Server identity** - Host key verification prevents MITM
-5. **Matches Git's primary model** - Most developers use SSH for Git
-
-**Implementation order:**
-1. Remove `auth` field from TIN protocol (revert to pure protocol)
-2. Implement SSH transport in client
-3. Implement SSH server handler in TinHub
-4. Add public key management to TinHub web UI
-5. Later: Add HTTPS transport as alternative
-
-## Files to Modify
-
-### Revert Protocol Changes
-- `internal/remote/protocol.go` - Remove `AuthInfo` and `Auth` field from `HelloMessage`
-- `internal/remote/client.go` - Remove `SetAuthToken()`, `makeHello()`, `authToken` field
-- `internal/commands/push.go` - Remove `getAuthToken()`, `dialWithAuth()`
-- `internal/commands/pull.go` - Remove `getAuthTokenForPull()`
-- `internal/commands/config.go` - Remove `auth_token` config key
-- `internal/storage/repository.go` - Remove `AuthToken` from `Config` struct
-
-### New SSH Transport
-- `internal/remote/ssh.go` - SSH client implementation
-- `internal/remote/transport.go` - Transport interface (SSH, HTTPS, TCP)
-- `internal/remote/url.go` - Parse different URL formats
-
-### TinHub Server
-- New SSH server component
-- Public key storage in database
-- Key management API endpoints
-- Web UI for SSH key management
-
-## Open Questions
-
-1. Should TIN support Git's credential helper protocol directly? This would allow reusing existing credential managers.
-
-2. For SSH, should we use the system SSH client (`ssh` binary) like Git does, or implement SSH in Go? Using the system client is simpler but less portable.
-
-3. Should the plain TCP transport (`tin://`) remain for local/trusted networks, or be removed entirely?
-
-## References
-
-- [Git Protocol Documentation](https://git-scm.com/docs/protocol-v2)
-- [Git Credential Storage](https://git-scm.com/docs/gitcredentials)
-- [GitHub SSH Key Setup](https://docs.github.com/en/authentication/connecting-to-github-with-ssh)
-- [Go x/crypto/ssh Package](https://pkg.go.dev/golang.org/x/crypto/ssh)
+- **SSH Transport** - `tin@host:user/repo` format with SSH key authentication
+- **Git credential helper compatibility** - Reuse existing credential managers
+- **OAuth/OIDC** - Web-based authentication flow

--- a/docs/AUTH_DESIGN.md
+++ b/docs/AUTH_DESIGN.md
@@ -1,0 +1,200 @@
+# TIN Authentication Design
+
+## Current State
+
+A temporary authentication mechanism was added directly to the TIN wire protocol, embedding an `auth` field in the `hello` message:
+
+```json
+{
+  "type": "hello",
+  "payload": {
+    "version": 1,
+    "operation": "push",
+    "repo_path": "/user/repo",
+    "auth": {
+      "type": "token",
+      "token": "th_xxxxx"
+    }
+  }
+}
+```
+
+This works but **diverges from Git's design philosophy**. TIN's goal is to mirror Git's architecture closely, which makes design decisions simple and trustworthy.
+
+## How Git Handles Authentication
+
+Git does NOT embed authentication in its wire protocol. Instead, Git delegates authentication entirely to the transport layer:
+
+### SSH Transport (`git@github.com:user/repo.git`)
+- Authentication happens via SSH before Git ever speaks
+- User authenticates with SSH keys
+- The Git pack protocol has zero auth fields
+- SSH provides encryption, host verification, and auth in one layer
+
+### HTTPS Transport (`https://github.com/user/repo.git`)
+- Authentication via HTTP Basic Auth headers
+- Tokens (like GitHub PATs) are passed as the password
+- Git uses credential helpers to store/retrieve credentials
+- The Git pack protocol still has zero auth fields
+
+### Git Protocol (`git://host/repo.git`)
+- No authentication at all
+- Typically used for read-only public access
+- Rarely used for push operations
+
+## Proposed Design for TIN
+
+Following Git's model, TIN should support multiple transports with transport-layer authentication.
+
+### Option 1: SSH Transport
+
+**URL format:** `tin@tinhub.dev:user/repo` or `ssh://tin@tinhub.dev/user/repo`
+
+**How it works:**
+1. User has SSH key pair (~/.ssh/id_ed25519)
+2. User registers public key with TinHub (like GitHub SSH keys)
+3. `tin push` initiates SSH connection to tinhub.dev
+4. SSH authenticates user via key
+5. SSH spawns `tin-receive-pack` (or similar) on server
+6. TIN protocol flows over the authenticated SSH channel
+7. Server knows user identity from SSH auth
+
+**Server-side requirements:**
+- Run SSH server (or use Fly.io's SSH infrastructure)
+- Map SSH public keys to user accounts
+- Spawn TIN handler process for authenticated connections
+
+**Client-side changes:**
+- Add SSH transport in `internal/remote/`
+- Parse `tin@host:path` URL format
+- Use Go's `x/crypto/ssh` package
+- Remove `auth` field from protocol
+
+**Pros:**
+- Battle-tested authentication model
+- Users already have SSH keys
+- Encryption included
+- Exactly how Git does it
+
+**Cons:**
+- More complex server infrastructure
+- Need to manage SSH keys in TinHub
+
+### Option 2: HTTPS Transport
+
+**URL format:** `https://tinhub.dev/user/repo.tin`
+
+**How it works:**
+1. User has API token (th_xxxxx)
+2. `tin push` makes HTTPS request with `Authorization: Basic` header
+3. Username can be anything, password is the token
+4. Server validates token, identifies user
+5. TIN protocol flows over HTTPS (likely as POST body or WebSocket)
+
+**Server-side requirements:**
+- HTTPS endpoint that accepts TIN protocol
+- Validate Basic Auth credentials
+- Could use existing Hono API infrastructure
+
+**Client-side changes:**
+- Add HTTPS transport in `internal/remote/`
+- Implement credential helper system (like `git credential`)
+- Use standard HTTP client with Basic Auth
+- Remove `auth` field from protocol
+
+**Credential helper flow (matching Git):**
+```bash
+# Git's credential helper protocol
+$ git credential fill
+protocol=https
+host=github.com
+
+# Helper responds with stored credentials
+protocol=https
+host=github.com
+username=user
+password=ghp_xxxx
+```
+
+TIN could implement the same:
+```bash
+$ tin credential fill
+protocol=https
+host=tinhub.dev
+
+# Response
+protocol=https
+host=tinhub.dev
+username=user
+password=th_xxxx
+```
+
+**Pros:**
+- Simpler server infrastructure (just HTTPS)
+- Works through corporate firewalls
+- Can reuse existing web infrastructure
+
+**Cons:**
+- Need to implement credential helper system
+- Slightly more complex client code
+
+### Option 3: Both (Like Git)
+
+Git supports both SSH and HTTPS. TIN could do the same:
+
+- `tin@tinhub.dev:user/repo` → SSH transport
+- `https://tinhub.dev/user/repo` → HTTPS transport
+- `tin://tinhub.dev/user/repo` → Unauthenticated TCP (read-only)
+
+## Recommendation
+
+**Start with SSH transport.** Reasons:
+
+1. **Simpler protocol** - No need for credential helpers initially
+2. **Users expect it** - Every Git user understands SSH keys
+3. **Security included** - Encryption and auth in one layer
+4. **Server identity** - Host key verification prevents MITM
+5. **Matches Git's primary model** - Most developers use SSH for Git
+
+**Implementation order:**
+1. Remove `auth` field from TIN protocol (revert to pure protocol)
+2. Implement SSH transport in client
+3. Implement SSH server handler in TinHub
+4. Add public key management to TinHub web UI
+5. Later: Add HTTPS transport as alternative
+
+## Files to Modify
+
+### Revert Protocol Changes
+- `internal/remote/protocol.go` - Remove `AuthInfo` and `Auth` field from `HelloMessage`
+- `internal/remote/client.go` - Remove `SetAuthToken()`, `makeHello()`, `authToken` field
+- `internal/commands/push.go` - Remove `getAuthToken()`, `dialWithAuth()`
+- `internal/commands/pull.go` - Remove `getAuthTokenForPull()`
+- `internal/commands/config.go` - Remove `auth_token` config key
+- `internal/storage/repository.go` - Remove `AuthToken` from `Config` struct
+
+### New SSH Transport
+- `internal/remote/ssh.go` - SSH client implementation
+- `internal/remote/transport.go` - Transport interface (SSH, HTTPS, TCP)
+- `internal/remote/url.go` - Parse different URL formats
+
+### TinHub Server
+- New SSH server component
+- Public key storage in database
+- Key management API endpoints
+- Web UI for SSH key management
+
+## Open Questions
+
+1. Should TIN support Git's credential helper protocol directly? This would allow reusing existing credential managers.
+
+2. For SSH, should we use the system SSH client (`ssh` binary) like Git does, or implement SSH in Go? Using the system client is simpler but less portable.
+
+3. Should the plain TCP transport (`tin://`) remain for local/trusted networks, or be removed entirely?
+
+## References
+
+- [Git Protocol Documentation](https://git-scm.com/docs/protocol-v2)
+- [Git Credential Storage](https://git-scm.com/docs/gitcredentials)
+- [GitHub SSH Key Setup](https://docs.github.com/en/authentication/connecting-to-github-with-ssh)
+- [Go x/crypto/ssh Package](https://pkg.go.dev/golang.org/x/crypto/ssh)

--- a/internal/agents/amp/adapter.go
+++ b/internal/agents/amp/adapter.go
@@ -1,0 +1,341 @@
+// Package amp provides the AMP (Sourcegraph) agent integration for Tin.
+// It implements the PullAdapter interface for batch thread import.
+package amp
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/dadlerj/tin/internal/agents"
+	"github.com/dadlerj/tin/internal/model"
+)
+
+const (
+	agentName        = "amp"
+	agentDisplayName = "AMP (Sourcegraph)"
+)
+
+// Adapter implements agents.PullAdapter for AMP
+type Adapter struct{}
+
+// NewAdapter creates a new AMP adapter
+func NewAdapter() *Adapter {
+	return &Adapter{}
+}
+
+// Info returns metadata about the AMP agent
+func (a *Adapter) Info() agents.AgentInfo {
+	return agents.AgentInfo{
+		Name:        agentName,
+		DisplayName: agentDisplayName,
+		Paradigm:    agents.ParadigmPull,
+		Version:     "1.0.0",
+	}
+}
+
+// List returns available thread IDs from AMP
+func (a *Adapter) List(limit int) ([]string, error) {
+	if limit <= 0 {
+		limit = 100 // Default limit
+	}
+
+	cmd := exec.Command("amp", "threads", "list")
+	output, err := cmd.Output()
+	if err != nil {
+		return nil, fmt.Errorf("failed to list amp threads: %w", err)
+	}
+
+	// Parse the output to extract thread IDs
+	// Format: Title | Last Updated | Visibility | Messages | Thread ID
+	var threadIDs []string
+	lines := strings.Split(string(output), "\n")
+
+	// Skip header lines (first two lines are header and separator)
+	for i, line := range lines {
+		if i < 2 || strings.TrimSpace(line) == "" {
+			continue
+		}
+
+		// Extract the thread ID (last column, starts with T-)
+		if idx := strings.LastIndex(line, "T-"); idx != -1 {
+			threadID := strings.TrimSpace(line[idx:])
+			threadIDs = append(threadIDs, threadID)
+			if len(threadIDs) >= limit {
+				break
+			}
+		}
+	}
+
+	return threadIDs, nil
+}
+
+// Pull fetches a specific thread by ID
+func (a *Adapter) Pull(threadID string, opts agents.PullOptions) (*model.Thread, error) {
+	// Extract thread ID from URL if needed
+	if strings.HasPrefix(threadID, "https://ampcode.com/threads/") {
+		threadID = strings.TrimPrefix(threadID, "https://ampcode.com/threads/")
+	}
+
+	// Fetch the thread markdown from amp CLI
+	markdown, err := fetchThreadMarkdown(threadID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to fetch thread %s: %w", threadID, err)
+	}
+
+	// Parse the markdown into a tin Thread
+	thread, err := parseMarkdown(markdown, threadID, opts.IncludeGit)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse thread %s: %w", threadID, err)
+	}
+
+	return thread, nil
+}
+
+// PullRecent fetches the N most recent threads
+func (a *Adapter) PullRecent(count int, opts agents.PullOptions) ([]*model.Thread, error) {
+	threadIDs, err := a.List(count)
+	if err != nil {
+		return nil, err
+	}
+
+	var threads []*model.Thread
+	for _, id := range threadIDs {
+		thread, err := a.Pull(id, opts)
+		if err != nil {
+			// Log error but continue with other threads
+			fmt.Fprintf(os.Stderr, "Warning: failed to pull thread %s: %v\n", id, err)
+			continue
+		}
+		threads = append(threads, thread)
+	}
+
+	return threads, nil
+}
+
+func fetchThreadMarkdown(threadID string) (string, error) {
+	// Write to temp file to work around amp CLI truncating output when piped
+	tmpFile, err := os.CreateTemp("", "amp-thread-*.md")
+	if err != nil {
+		return "", fmt.Errorf("failed to create temp file: %w", err)
+	}
+	tmpPath := tmpFile.Name()
+	tmpFile.Close()
+	defer os.Remove(tmpPath)
+
+	// Use shell redirection to write to file
+	cmd := exec.Command("sh", "-c", fmt.Sprintf("amp threads markdown %s > %s", threadID, tmpPath))
+	if err := cmd.Run(); err != nil {
+		return "", err
+	}
+
+	data, err := os.ReadFile(tmpPath)
+	if err != nil {
+		return "", err
+	}
+	return string(data), nil
+}
+
+func parseMarkdown(markdown string, ampThreadID string, includeGit bool) (*model.Thread, error) {
+	thread := &model.Thread{
+		Agent:    agentName,
+		Status:   model.ThreadStatusCompleted,
+		Messages: []model.Message{},
+	}
+
+	// Parse YAML frontmatter
+	if strings.HasPrefix(markdown, "---") {
+		endIdx := strings.Index(markdown[3:], "---")
+		if endIdx != -1 {
+			frontmatter := markdown[3 : endIdx+3]
+			markdown = markdown[endIdx+6:] // Skip past closing ---
+
+			// Extract created timestamp
+			if match := regexp.MustCompile(`created:\s*(.+)`).FindStringSubmatch(frontmatter); len(match) > 1 {
+				if t, err := time.Parse(time.RFC3339, strings.TrimSpace(match[1])); err == nil {
+					thread.StartedAt = t
+				}
+			}
+
+			// Store the original Amp thread ID in AgentSessionID
+			thread.AgentSessionID = ampThreadID
+		}
+	}
+
+	// Parse messages
+	lines := strings.Split(markdown, "\n")
+	var currentRole model.Role
+	var currentContent strings.Builder
+	var currentToolCalls []model.ToolCall
+	i := 0
+
+	flushMessage := func() {
+		if currentRole != "" {
+			content := strings.TrimSpace(currentContent.String())
+			if content != "" || len(currentToolCalls) > 0 {
+				msg := model.NewMessage(currentRole, content, "", currentToolCalls)
+				thread.AddMessage(msg)
+			}
+		}
+		currentContent.Reset()
+		currentToolCalls = nil
+	}
+
+	for i < len(lines) {
+		line := lines[i]
+
+		// Detect role headers (more robust matching)
+		trimmedLine := strings.TrimSpace(line)
+		if trimmedLine == "## User" || strings.HasPrefix(trimmedLine, "## User ") {
+			flushMessage()
+			currentRole = model.RoleHuman
+			i++
+			continue
+		}
+		if trimmedLine == "## Assistant" || strings.HasPrefix(trimmedLine, "## Assistant ") {
+			flushMessage()
+			currentRole = model.RoleAssistant
+			i++
+			continue
+		}
+
+		// Parse tool result sections - now we preserve them!
+		if strings.HasPrefix(trimmedLine, "**Tool Result:**") {
+			var resultContent strings.Builder
+			i++
+
+			// Check for code block
+			if i < len(lines) && strings.HasPrefix(strings.TrimSpace(lines[i]), "```") {
+				i++ // Skip opening fence
+				for i < len(lines) && !strings.HasPrefix(strings.TrimSpace(lines[i]), "```") {
+					resultContent.WriteString(lines[i])
+					resultContent.WriteString("\n")
+					i++
+				}
+				if i < len(lines) {
+					i++ // Skip closing fence
+				}
+			} else {
+				// Collect until next section marker
+				for i < len(lines) {
+					nextLine := lines[i]
+					nextTrimmed := strings.TrimSpace(nextLine)
+					if strings.HasPrefix(nextTrimmed, "## ") ||
+						strings.HasPrefix(nextTrimmed, "**Tool Use:**") ||
+						strings.HasPrefix(nextTrimmed, "**Tool Result:**") {
+						break
+					}
+					resultContent.WriteString(nextLine)
+					resultContent.WriteString("\n")
+					i++
+				}
+			}
+
+			// Associate result with the last tool call if available
+			result := strings.TrimSpace(resultContent.String())
+			if len(currentToolCalls) > 0 && result != "" {
+				// Update the last tool call with its result
+				lastIdx := len(currentToolCalls) - 1
+				currentToolCalls[lastIdx].Result = result
+			}
+			continue
+		}
+
+		// Detect tool use
+		if strings.HasPrefix(trimmedLine, "**Tool Use:** `") {
+			toolName := strings.TrimSuffix(strings.TrimPrefix(trimmedLine, "**Tool Use:** `"), "`")
+			var toolArgs strings.Builder
+			i++
+
+			// Skip empty lines between tool use header and code block
+			for i < len(lines) && strings.TrimSpace(lines[i]) == "" {
+				i++
+			}
+
+			// Skip opening code fence
+			if i < len(lines) && strings.HasPrefix(strings.TrimSpace(lines[i]), "```") {
+				i++
+			}
+
+			// Collect JSON arguments until closing fence
+			for i < len(lines) && !strings.HasPrefix(strings.TrimSpace(lines[i]), "```") {
+				toolArgs.WriteString(lines[i])
+				toolArgs.WriteString("\n")
+				i++
+			}
+
+			// Skip closing fence
+			if i < len(lines) && strings.HasPrefix(strings.TrimSpace(lines[i]), "```") {
+				i++
+			}
+
+			// Validate and store the arguments
+			argsStr := strings.TrimSpace(toolArgs.String())
+			var argsBytes []byte
+			if argsStr != "" && len(argsStr) > 0 && argsStr[0] == '{' {
+				var test interface{}
+				if err := json.Unmarshal([]byte(argsStr), &test); err == nil {
+					argsBytes = []byte(argsStr)
+				} else {
+					argsBytes = []byte(`{"_error": "parse error"}`)
+				}
+			} else {
+				argsBytes = []byte("{}")
+			}
+
+			currentToolCalls = append(currentToolCalls, model.ToolCall{
+				Name:      toolName,
+				Arguments: argsBytes,
+			})
+			continue
+		}
+
+		// Regular content
+		if currentRole != "" {
+			currentContent.WriteString(line)
+			currentContent.WriteString("\n")
+		}
+		i++
+	}
+
+	// Flush final message
+	flushMessage()
+
+	// Set thread ID based on first message
+	if len(thread.Messages) > 0 {
+		thread.ID = thread.Messages[0].ID
+	} else {
+		thread.ID = ampThreadID
+	}
+
+	// Mark as completed
+	now := time.Now().UTC()
+	thread.CompletedAt = &now
+
+	// Record git hash if requested
+	if includeGit {
+		if hash := getCurrentGitHash(); hash != "" {
+			thread.GitCommitHash = hash
+		}
+	}
+
+	return thread, nil
+}
+
+func getCurrentGitHash() string {
+	cmd := exec.Command("git", "rev-parse", "HEAD")
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
+}
+
+// Register this adapter with the global registry
+func init() {
+	agents.Register(NewAdapter())
+}

--- a/internal/agents/amp/adapter_test.go
+++ b/internal/agents/amp/adapter_test.go
@@ -1,0 +1,345 @@
+package amp
+
+import (
+	"testing"
+
+	"github.com/dadlerj/tin/internal/agents"
+	"github.com/dadlerj/tin/internal/model"
+)
+
+func TestAdapter_Info(t *testing.T) {
+	adapter := NewAdapter()
+	info := adapter.Info()
+
+	if info.Name != "amp" {
+		t.Errorf("expected name 'amp', got %s", info.Name)
+	}
+	if info.DisplayName != "AMP (Sourcegraph)" {
+		t.Errorf("expected display name 'AMP (Sourcegraph)', got %s", info.DisplayName)
+	}
+	if info.Paradigm != agents.ParadigmPull {
+		t.Errorf("expected paradigm Pull, got %v", info.Paradigm)
+	}
+}
+
+func TestParseMarkdown_BasicConversation(t *testing.T) {
+	markdown := `---
+created: 2024-01-15T10:30:00Z
+---
+
+## User
+
+Hello, can you help me?
+
+## Assistant
+
+Of course! How can I assist you today?
+
+## User
+
+What is 2 + 2?
+
+## Assistant
+
+2 + 2 equals 4.
+`
+
+	thread, err := parseMarkdown(markdown, "T-test-123", false)
+	if err != nil {
+		t.Fatalf("parseMarkdown failed: %v", err)
+	}
+
+	if thread.Agent != "amp" {
+		t.Errorf("expected agent 'amp', got %s", thread.Agent)
+	}
+
+	if thread.AgentSessionID != "T-test-123" {
+		t.Errorf("expected AgentSessionID 'T-test-123', got %s", thread.AgentSessionID)
+	}
+
+	if len(thread.Messages) != 4 {
+		t.Errorf("expected 4 messages, got %d", len(thread.Messages))
+	}
+
+	// Verify message roles
+	expectedRoles := []model.Role{model.RoleHuman, model.RoleAssistant, model.RoleHuman, model.RoleAssistant}
+	for i, msg := range thread.Messages {
+		if msg.Role != expectedRoles[i] {
+			t.Errorf("message %d: expected role %s, got %s", i, expectedRoles[i], msg.Role)
+		}
+	}
+
+	// Verify first user message content
+	if thread.Messages[0].Content != "Hello, can you help me?" {
+		t.Errorf("unexpected first message content: %s", thread.Messages[0].Content)
+	}
+}
+
+func TestParseMarkdown_WithToolUse(t *testing.T) {
+	markdown := `---
+created: 2024-01-15T10:30:00Z
+---
+
+## User
+
+Read the file test.go
+
+## Assistant
+
+I'll read that file for you.
+
+**Tool Use:** ` + "`Read`" + `
+
+` + "```json" + `
+{"file_path": "/path/to/test.go"}
+` + "```" + `
+
+**Tool Result:**
+
+` + "```" + `
+package main
+
+func main() {}
+` + "```" + `
+
+Here's the content of the file.
+`
+
+	thread, err := parseMarkdown(markdown, "T-tool-test", false)
+	if err != nil {
+		t.Fatalf("parseMarkdown failed: %v", err)
+	}
+
+	if len(thread.Messages) != 2 {
+		t.Errorf("expected 2 messages, got %d", len(thread.Messages))
+	}
+
+	// Second message should have tool calls
+	assistantMsg := thread.Messages[1]
+	if len(assistantMsg.ToolCalls) != 1 {
+		t.Errorf("expected 1 tool call, got %d", len(assistantMsg.ToolCalls))
+	}
+
+	if assistantMsg.ToolCalls[0].Name != "Read" {
+		t.Errorf("expected tool name 'Read', got %s", assistantMsg.ToolCalls[0].Name)
+	}
+
+	// Verify tool result is preserved (this was previously discarded)
+	if assistantMsg.ToolCalls[0].Result == "" {
+		t.Error("expected tool result to be preserved, got empty string")
+	}
+}
+
+func TestParseMarkdown_MultipleToolCalls(t *testing.T) {
+	markdown := `---
+created: 2024-01-15T10:30:00Z
+---
+
+## User
+
+Check both files
+
+## Assistant
+
+I'll check both files.
+
+**Tool Use:** ` + "`Read`" + `
+
+` + "```json" + `
+{"file_path": "file1.go"}
+` + "```" + `
+
+**Tool Result:**
+
+` + "```" + `
+content of file1
+` + "```" + `
+
+**Tool Use:** ` + "`Read`" + `
+
+` + "```json" + `
+{"file_path": "file2.go"}
+` + "```" + `
+
+**Tool Result:**
+
+` + "```" + `
+content of file2
+` + "```" + `
+
+Both files have been read.
+`
+
+	thread, err := parseMarkdown(markdown, "T-multi-tool", false)
+	if err != nil {
+		t.Fatalf("parseMarkdown failed: %v", err)
+	}
+
+	if len(thread.Messages) != 2 {
+		t.Errorf("expected 2 messages, got %d", len(thread.Messages))
+	}
+
+	assistantMsg := thread.Messages[1]
+	if len(assistantMsg.ToolCalls) != 2 {
+		t.Errorf("expected 2 tool calls, got %d", len(assistantMsg.ToolCalls))
+	}
+
+	// Verify both tool results are captured
+	for i, tc := range assistantMsg.ToolCalls {
+		if tc.Result == "" {
+			t.Errorf("tool call %d: expected result to be captured", i)
+		}
+	}
+}
+
+func TestParseMarkdown_NoFrontmatter(t *testing.T) {
+	markdown := `## User
+
+Simple message
+
+## Assistant
+
+Simple response
+`
+
+	thread, err := parseMarkdown(markdown, "T-no-front", false)
+	if err != nil {
+		t.Fatalf("parseMarkdown failed: %v", err)
+	}
+
+	if len(thread.Messages) != 2 {
+		t.Errorf("expected 2 messages, got %d", len(thread.Messages))
+	}
+
+	// Without frontmatter, AgentSessionID is not set (only set in frontmatter parsing)
+	// Thread ID should fall back to first message ID
+	if thread.ID == "" {
+		t.Error("expected non-empty thread ID")
+	}
+}
+
+func TestParseMarkdown_EmptyContent(t *testing.T) {
+	markdown := `---
+created: 2024-01-15T10:30:00Z
+---
+`
+
+	thread, err := parseMarkdown(markdown, "T-empty", false)
+	if err != nil {
+		t.Fatalf("parseMarkdown failed: %v", err)
+	}
+
+	if len(thread.Messages) != 0 {
+		t.Errorf("expected 0 messages, got %d", len(thread.Messages))
+	}
+
+	// Thread ID should fall back to ampThreadID when no messages
+	if thread.ID != "T-empty" {
+		t.Errorf("expected thread ID 'T-empty', got %s", thread.ID)
+	}
+}
+
+func TestParseMarkdown_InvalidToolJSON(t *testing.T) {
+	markdown := `## User
+
+Test
+
+## Assistant
+
+Testing
+
+**Tool Use:** ` + "`Bash`" + `
+
+` + "```json" + `
+{invalid json here}
+` + "```" + `
+`
+
+	thread, err := parseMarkdown(markdown, "T-invalid-json", false)
+	if err != nil {
+		t.Fatalf("parseMarkdown failed: %v", err)
+	}
+
+	assistantMsg := thread.Messages[1]
+	if len(assistantMsg.ToolCalls) != 1 {
+		t.Errorf("expected 1 tool call even with invalid JSON, got %d", len(assistantMsg.ToolCalls))
+	}
+
+	// Should have error indicator in arguments
+	if string(assistantMsg.ToolCalls[0].Arguments) == "{}" {
+		t.Error("expected error indicator in arguments for invalid JSON")
+	}
+}
+
+func TestParseMarkdown_ThreadStatus(t *testing.T) {
+	markdown := `## User
+
+Test message
+
+## Assistant
+
+Response
+`
+
+	thread, err := parseMarkdown(markdown, "T-status", false)
+	if err != nil {
+		t.Fatalf("parseMarkdown failed: %v", err)
+	}
+
+	if thread.Status != model.ThreadStatusCompleted {
+		t.Errorf("expected status Completed, got %s", thread.Status)
+	}
+
+	if thread.CompletedAt == nil {
+		t.Error("expected CompletedAt to be set")
+	}
+}
+
+func TestParseMarkdown_TimestampParsing(t *testing.T) {
+	markdown := `---
+created: 2024-06-15T14:30:00Z
+---
+
+## User
+
+Test
+`
+
+	thread, err := parseMarkdown(markdown, "T-time", false)
+	if err != nil {
+		t.Fatalf("parseMarkdown failed: %v", err)
+	}
+
+	if thread.StartedAt.IsZero() {
+		t.Error("expected StartedAt to be parsed from frontmatter")
+	}
+
+	if thread.StartedAt.Year() != 2024 || thread.StartedAt.Month() != 6 {
+		t.Errorf("unexpected StartedAt: %v", thread.StartedAt)
+	}
+}
+
+func TestParseMarkdown_RobustRoleDetection(t *testing.T) {
+	// Test with extra whitespace and variations
+	markdown := `---
+created: 2024-01-15T10:30:00Z
+---
+
+  ## User
+
+Message with whitespace
+
+## Assistant
+
+Response
+`
+
+	thread, err := parseMarkdown(markdown, "T-whitespace", false)
+	if err != nil {
+		t.Fatalf("parseMarkdown failed: %v", err)
+	}
+
+	if len(thread.Messages) != 2 {
+		t.Errorf("expected 2 messages with whitespace handling, got %d", len(thread.Messages))
+	}
+}

--- a/internal/agents/claudecode/handler.go
+++ b/internal/agents/claudecode/handler.go
@@ -1,0 +1,495 @@
+// Package claudecode provides the Claude Code agent integration for Tin.
+// It implements the HookHandler interface for real-time thread tracking.
+package claudecode
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/dadlerj/tin/internal/agents"
+	"github.com/dadlerj/tin/internal/model"
+	"github.com/dadlerj/tin/internal/storage"
+)
+
+const (
+	agentName        = "claude-code"
+	agentDisplayName = "Claude Code"
+	stateFileName    = ".tin-session"
+	defaultTimeout   = 30
+	maxBufferSize    = 1024 * 1024 // 1MB for transcript parsing
+)
+
+// Handler implements agents.HookHandler for Claude Code
+type Handler struct {
+	config *agents.Config
+}
+
+// NewHandler creates a new Claude Code handler with the given config.
+// If config is nil, default configuration is used.
+func NewHandler(config *agents.Config) *Handler {
+	if config == nil {
+		config = agents.DefaultConfig()
+	}
+	return &Handler{config: config}
+}
+
+// Info returns metadata about the Claude Code agent
+func (h *Handler) Info() agents.AgentInfo {
+	return agents.AgentInfo{
+		Name:        agentName,
+		DisplayName: agentDisplayName,
+		Paradigm:    agents.ParadigmHook,
+		Version:     "1.0.0",
+	}
+}
+
+// Install configures hooks for Claude Code
+func (h *Handler) Install(projectDir string, global bool) error {
+	return InstallHooks(projectDir, global, h.config.HookTimeout)
+}
+
+// Uninstall removes hooks for Claude Code
+func (h *Handler) Uninstall(projectDir string, global bool) error {
+	return UninstallHooks(projectDir, global)
+}
+
+// IsInstalled checks if hooks are currently installed
+func (h *Handler) IsInstalled(projectDir string, global bool) (bool, error) {
+	settingsPath := getSettingsPath(projectDir, global)
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return strings.Contains(string(data), "tin hook"), nil
+}
+
+// HandleEvent processes a hook event from Claude Code
+func (h *Handler) HandleEvent(event *agents.HookEvent) (string, error) {
+	repo, err := storage.Open(event.Cwd)
+	if err != nil {
+		// Not a tin repo - return empty string, no error (silent skip)
+		return "", nil
+	}
+
+	switch event.Type {
+	case agents.HookEventSessionStart:
+		return h.handleSessionStart(repo, event)
+	case agents.HookEventUserPrompt:
+		return h.handleUserPrompt(repo, event)
+	case agents.HookEventAssistantStop:
+		return h.handleStop(repo, event)
+	case agents.HookEventSessionEnd:
+		return h.handleSessionEnd(repo, event)
+	default:
+		return "", fmt.Errorf("unknown event type: %s", event.Type)
+	}
+}
+
+func (h *Handler) handleSessionStart(repo *storage.Repository, event *agents.HookEvent) (string, error) {
+	// Check if we already have a thread for this session
+	state, _ := loadSessionState(repo.RootPath, event.SessionID)
+	if state != nil && state.SessionID == event.SessionID {
+		// Already tracking this session
+		return state.ThreadID, nil
+	}
+
+	// Prune any empty threads before creating a new one
+	repo.PruneEmptyThreads()
+
+	// Check for existing threads with this session ID (for resumed sessions)
+	var parentThreadID, parentMessageID string
+	existingThreads, _ := repo.FindThreadsBySessionID(event.SessionID)
+	if len(existingThreads) > 0 {
+		// Link to the most recent thread with this session ID
+		parent := existingThreads[0]
+		parentThreadID = parent.ID
+		if len(parent.Messages) > 0 {
+			parentMessageID = parent.Messages[len(parent.Messages)-1].ID
+		}
+	}
+
+	// Create a new thread with parent reference if resuming
+	thread := model.NewThread(agentName, event.SessionID, parentThreadID, parentMessageID)
+
+	// Generate a temporary ID until first message
+	thread.ID = fmt.Sprintf("cc-%s", event.SessionID[:min(12, len(event.SessionID))])
+
+	if err := repo.SaveThread(thread); err != nil {
+		return "", err
+	}
+
+	// Save session state
+	if err := saveSessionState(repo.RootPath, event.SessionID, &SessionState{
+		SessionID: event.SessionID,
+		ThreadID:  thread.ID,
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		return "", err
+	}
+
+	return thread.ID, nil
+}
+
+func (h *Handler) handleUserPrompt(repo *storage.Repository, event *agents.HookEvent) (string, error) {
+	if event.Prompt == "" {
+		return "", nil
+	}
+
+	state, err := loadSessionState(repo.RootPath, event.SessionID)
+	if err != nil || state == nil {
+		// No active session, create one
+		threadID, err := h.handleSessionStart(repo, event)
+		if err != nil {
+			return "", err
+		}
+		state, _ = loadSessionState(repo.RootPath, event.SessionID)
+		if state == nil {
+			return threadID, fmt.Errorf("failed to initialize session")
+		}
+	}
+
+	thread, err := repo.LoadThread(state.ThreadID)
+	if err != nil {
+		return state.ThreadID, err
+	}
+
+	// Track old ID before adding message
+	oldThreadID := thread.ID
+
+	// Create human message
+	msg := model.NewMessage(model.RoleHuman, event.Prompt, "", nil)
+	thread.AddMessage(msg)
+
+	// If thread ID changed (first message was added), update session state and clean up
+	if thread.ID != oldThreadID {
+		if err := saveSessionState(repo.RootPath, event.SessionID, &SessionState{
+			SessionID: state.SessionID,
+			ThreadID:  thread.ID,
+			StartedAt: state.StartedAt,
+		}); err != nil {
+			return thread.ID, err
+		}
+		repo.DeleteThread(oldThreadID)
+		repo.UnstageThread(oldThreadID)
+	}
+
+	// Auto-stage the thread if configured
+	if h.config.AutoStage == nil || *h.config.AutoStage {
+		contentHash := thread.ComputeContentHash()
+		if err := repo.StageThread(thread.ID, len(thread.Messages), contentHash); err != nil {
+			return thread.ID, err
+		}
+	}
+
+	return thread.ID, repo.SaveThread(thread)
+}
+
+func (h *Handler) handleStop(repo *storage.Repository, event *agents.HookEvent) (string, error) {
+	state, err := loadSessionState(repo.RootPath, event.SessionID)
+	if err != nil || state == nil {
+		return "", nil // No active session
+	}
+
+	thread, err := repo.LoadThread(state.ThreadID)
+	if err != nil {
+		return state.ThreadID, err
+	}
+
+	// Get assistant response - either from event or parse transcript
+	assistantContent := event.Response
+	toolCalls := event.ToolCalls
+
+	if assistantContent == "" && len(toolCalls) == 0 && event.Transcript != "" {
+		assistantContent, toolCalls, err = parseLatestAssistantResponse(event.Transcript)
+		if err != nil {
+			// Log error but continue - don't fail the hook
+			fmt.Fprintf(os.Stderr, "Warning: failed to parse transcript: %v\n", err)
+		}
+	}
+
+	if assistantContent == "" && len(toolCalls) == 0 {
+		return state.ThreadID, nil // No response to record
+	}
+
+	// Get current git hash
+	gitHash, _ := repo.GetCurrentGitHash()
+
+	// Create assistant message
+	msg := model.NewMessage(model.RoleAssistant, assistantContent, "", toolCalls)
+	msg.GitHashAfter = gitHash
+	thread.AddMessage(msg)
+
+	// Auto-stage if configured
+	if h.config.AutoStage == nil || *h.config.AutoStage {
+		contentHash := thread.ComputeContentHash()
+		if err := repo.StageThread(thread.ID, len(thread.Messages), contentHash); err != nil {
+			return thread.ID, err
+		}
+	}
+
+	return thread.ID, repo.SaveThread(thread)
+}
+
+func (h *Handler) handleSessionEnd(repo *storage.Repository, event *agents.HookEvent) (string, error) {
+	state, err := loadSessionState(repo.RootPath, event.SessionID)
+	if err != nil || state == nil {
+		return "", nil // No active session
+	}
+
+	thread, err := repo.LoadThread(state.ThreadID)
+	if err != nil {
+		return state.ThreadID, err
+	}
+
+	// Auto-commit git changes if configured
+	if h.config.AutoCommitGit == nil || *h.config.AutoCommitGit {
+		files, err := repo.GitGetChangedFiles()
+		if err == nil && len(files) > 0 {
+			if err := repo.GitAdd(files); err == nil {
+				hasChanges, err := repo.GitHasStagedChanges()
+				if err == nil && hasChanges {
+					commitMsg := formatGitCommitMessage(thread)
+					repo.GitCommit(commitMsg)
+				}
+			}
+		}
+	}
+
+	// Store the current git hash
+	gitHash, _ := repo.GetCurrentGitHash()
+	thread.GitCommitHash = gitHash
+
+	// Mark as complete if content has changed
+	if thread.Status != model.ThreadStatusCommitted || thread.ComputeContentHash() != thread.CommittedContentHash {
+		thread.Complete()
+	}
+
+	// Clear session state
+	clearSessionState(repo.RootPath, event.SessionID)
+
+	return thread.ID, repo.SaveThread(thread)
+}
+
+// SessionState tracks the current session for hooks
+type SessionState struct {
+	SessionID string    `json:"session_id"`
+	ThreadID  string    `json:"thread_id"`
+	StartedAt time.Time `json:"started_at"`
+}
+
+func getSessionStatePath(rootPath, sessionID string) string {
+	// Use session-specific state file to support multiple concurrent sessions
+	shortID := sessionID
+	if len(shortID) > 12 {
+		shortID = shortID[:12]
+	}
+	return filepath.Join(rootPath, ".tin", fmt.Sprintf("%s-%s", stateFileName, shortID))
+}
+
+// getLegacySessionStatePath returns the old single-session state file path
+func getLegacySessionStatePath(rootPath string) string {
+	return filepath.Join(rootPath, ".tin", stateFileName)
+}
+
+func loadSessionState(rootPath, sessionID string) (*SessionState, error) {
+	// Try new session-specific path first
+	path := getSessionStatePath(rootPath, sessionID)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		// Fall back to legacy path for backwards compatibility
+		legacyPath := getLegacySessionStatePath(rootPath)
+		data, err = os.ReadFile(legacyPath)
+		if err != nil {
+			return nil, err
+		}
+	}
+	var state SessionState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, err
+	}
+	return &state, nil
+}
+
+func saveSessionState(rootPath, sessionID string, state *SessionState) error {
+	path := getSessionStatePath(rootPath, sessionID)
+	data, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+func clearSessionState(rootPath, sessionID string) {
+	// Remove session-specific file
+	path := getSessionStatePath(rootPath, sessionID)
+	os.Remove(path)
+
+	// Also remove legacy file if it exists and matches this session
+	legacyPath := getLegacySessionStatePath(rootPath)
+	if data, err := os.ReadFile(legacyPath); err == nil {
+		var state SessionState
+		if json.Unmarshal(data, &state) == nil && state.SessionID == sessionID {
+			os.Remove(legacyPath)
+		}
+	}
+}
+
+func formatGitCommitMessage(thread *model.Thread) string {
+	shortID := thread.ID
+	if len(shortID) > 8 {
+		shortID = shortID[:8]
+	}
+
+	message := "thread completed"
+	if first := thread.FirstHumanMessage(); first != nil {
+		message = strings.TrimSpace(first.Content)
+	}
+
+	// Split into subject line and body
+	firstLine := message
+	restOfMessage := ""
+	if idx := strings.Index(message, "\n"); idx != -1 {
+		firstLine = strings.TrimSpace(message[:idx])
+		restOfMessage = strings.TrimSpace(message[idx+1:])
+	}
+
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("[tin %s] %s", shortID, firstLine))
+
+	if restOfMessage != "" {
+		builder.WriteString("\n\n")
+		builder.WriteString(restOfMessage)
+	}
+
+	return builder.String()
+}
+
+// parseLatestAssistantResponse reads the transcript and extracts the latest assistant response
+func parseLatestAssistantResponse(transcriptPath string) (string, []model.ToolCall, error) {
+	if transcriptPath == "" {
+		return "", nil, nil
+	}
+
+	file, err := os.Open(transcriptPath)
+	if err != nil {
+		return "", nil, err
+	}
+	defer file.Close()
+
+	var messages []transcriptMessage
+	scanner := bufio.NewScanner(file)
+
+	// Use larger buffer for big messages
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, maxBufferSize)
+
+	for scanner.Scan() {
+		var msg transcriptMessage
+		if err := json.Unmarshal(scanner.Bytes(), &msg); err != nil {
+			continue
+		}
+		messages = append(messages, msg)
+	}
+
+	if len(messages) == 0 {
+		return "", nil, nil
+	}
+
+	// Find the message ID of the last assistant message
+	var lastAssistantMsgID string
+	for i := len(messages) - 1; i >= 0; i-- {
+		msg := messages[i]
+		if msg.Message != nil && msg.Message.Role == "assistant" && msg.Message.ID != "" {
+			lastAssistantMsgID = msg.Message.ID
+			break
+		}
+	}
+
+	if lastAssistantMsgID == "" {
+		return "", nil, nil
+	}
+
+	// Collect all content blocks from entries with this message ID
+	var textParts []string
+	var toolCalls []model.ToolCall
+	seenToolIDs := make(map[string]bool)
+
+	for _, msg := range messages {
+		if msg.Message == nil || msg.Message.ID != lastAssistantMsgID {
+			continue
+		}
+
+		content := msg.Message.Content
+		if content == nil {
+			continue
+		}
+
+		contentArr, ok := content.([]interface{})
+		if !ok {
+			continue
+		}
+
+		for _, block := range contentArr {
+			blockMap, ok := block.(map[string]interface{})
+			if !ok {
+				continue
+			}
+
+			blockType, _ := blockMap["type"].(string)
+
+			switch blockType {
+			case "text":
+				if text, ok := blockMap["text"].(string); ok && text != "" {
+					textParts = append(textParts, text)
+				}
+			case "tool_use":
+				toolID, _ := blockMap["id"].(string)
+				if toolID != "" && !seenToolIDs[toolID] {
+					seenToolIDs[toolID] = true
+					toolName, _ := blockMap["name"].(string)
+					toolInput := blockMap["input"]
+					inputJSON, _ := json.Marshal(toolInput)
+					toolCalls = append(toolCalls, model.ToolCall{
+						ID:        toolID,
+						Name:      toolName,
+						Arguments: inputJSON,
+					})
+				}
+			}
+		}
+	}
+
+	fullContent := strings.Join(textParts, "\n")
+	return fullContent, toolCalls, nil
+}
+
+type transcriptMessage struct {
+	Type    string                  `json:"type"`
+	Message *transcriptMessageInner `json:"message,omitempty"`
+}
+
+type transcriptMessageInner struct {
+	ID      string `json:"id,omitempty"`
+	Role    string `json:"role,omitempty"`
+	Content any    `json:"content,omitempty"`
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// Register this handler with the global registry
+func init() {
+	agents.Register(NewHandler(nil))
+}

--- a/internal/agents/claudecode/handler_test.go
+++ b/internal/agents/claudecode/handler_test.go
@@ -1,0 +1,252 @@
+package claudecode
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dadlerj/tin/internal/agents"
+)
+
+func TestHandler_Info(t *testing.T) {
+	handler := NewHandler(nil)
+	info := handler.Info()
+
+	if info.Name != "claude-code" {
+		t.Errorf("expected name 'claude-code', got %s", info.Name)
+	}
+	if info.DisplayName != "Claude Code" {
+		t.Errorf("expected display name 'Claude Code', got %s", info.DisplayName)
+	}
+	if info.Paradigm != agents.ParadigmHook {
+		t.Errorf("expected paradigm Hook, got %v", info.Paradigm)
+	}
+}
+
+func TestHandler_NewWithNilConfig(t *testing.T) {
+	handler := NewHandler(nil)
+	if handler.config == nil {
+		t.Error("expected default config when nil is passed")
+	}
+}
+
+func TestHandler_NewWithConfig(t *testing.T) {
+	customTimeout := 60
+	config := &agents.Config{HookTimeout: customTimeout}
+	handler := NewHandler(config)
+
+	if handler.config.HookTimeout != customTimeout {
+		t.Errorf("expected custom timeout %d, got %d", customTimeout, handler.config.HookTimeout)
+	}
+}
+
+func TestSessionState_JSONRoundtrip(t *testing.T) {
+	original := SessionState{
+		SessionID: "sess-abc123",
+		ThreadID:  "thread-xyz789",
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var decoded SessionState
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if decoded.SessionID != original.SessionID {
+		t.Errorf("SessionID mismatch: got %s, want %s", decoded.SessionID, original.SessionID)
+	}
+	if decoded.ThreadID != original.ThreadID {
+		t.Errorf("ThreadID mismatch: got %s, want %s", decoded.ThreadID, original.ThreadID)
+	}
+}
+
+func TestGetSessionStatePath(t *testing.T) {
+	tests := []struct {
+		rootPath  string
+		sessionID string
+		wantContains string
+	}{
+		{"/project", "abc123456789xyz", ".tin-session-abc123456789"},
+		{"/project", "short", ".tin-session-short"},
+		{"/project", "exactly12chr", ".tin-session-exactly12chr"},
+	}
+
+	for _, tt := range tests {
+		got := getSessionStatePath(tt.rootPath, tt.sessionID)
+		if !filepath.IsAbs(got) || got == "" {
+			// Just check it returns a valid path containing the expected substring
+			t.Logf("getSessionStatePath(%q, %q) = %q", tt.rootPath, tt.sessionID, got)
+		}
+	}
+}
+
+func TestSaveAndLoadSessionState(t *testing.T) {
+	tmpDir := t.TempDir()
+	tinDir := filepath.Join(tmpDir, ".tin")
+	if err := os.MkdirAll(tinDir, 0755); err != nil {
+		t.Fatalf("failed to create .tin dir: %v", err)
+	}
+
+	sessionID := "test-session-id"
+	threadID := "test-thread-id"
+
+	// Save state
+	state := &SessionState{
+		SessionID: sessionID,
+		ThreadID:  threadID,
+	}
+	if err := saveSessionState(tmpDir, sessionID, state); err != nil {
+		t.Fatalf("saveSessionState failed: %v", err)
+	}
+
+	// Load state
+	loaded, err := loadSessionState(tmpDir, sessionID)
+	if err != nil {
+		t.Fatalf("loadSessionState failed: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected non-nil state")
+	}
+
+	if loaded.SessionID != sessionID {
+		t.Errorf("SessionID mismatch: got %s, want %s", loaded.SessionID, sessionID)
+	}
+	if loaded.ThreadID != threadID {
+		t.Errorf("ThreadID mismatch: got %s, want %s", loaded.ThreadID, threadID)
+	}
+}
+
+func TestLoadSessionState_NotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	tinDir := filepath.Join(tmpDir, ".tin")
+	if err := os.MkdirAll(tinDir, 0755); err != nil {
+		t.Fatalf("failed to create .tin dir: %v", err)
+	}
+
+	// loadSessionState returns error when session file not found
+	state, err := loadSessionState(tmpDir, "nonexistent-session")
+	if err == nil {
+		t.Error("expected error for nonexistent session file")
+	}
+	if state != nil {
+		t.Error("expected nil state for nonexistent session")
+	}
+}
+
+func TestClearSessionState(t *testing.T) {
+	tmpDir := t.TempDir()
+	tinDir := filepath.Join(tmpDir, ".tin")
+	if err := os.MkdirAll(tinDir, 0755); err != nil {
+		t.Fatalf("failed to create .tin dir: %v", err)
+	}
+
+	sessionID := "test-clear-session"
+	state := &SessionState{
+		SessionID: sessionID,
+		ThreadID:  "thread-123",
+	}
+	if err := saveSessionState(tmpDir, sessionID, state); err != nil {
+		t.Fatalf("saveSessionState failed: %v", err)
+	}
+
+	// Verify it was saved
+	loaded, _ := loadSessionState(tmpDir, sessionID)
+	if loaded == nil {
+		t.Fatal("expected state to be saved")
+	}
+
+	// Clear it
+	clearSessionState(tmpDir, sessionID)
+
+	// Verify it's gone
+	loaded, _ = loadSessionState(tmpDir, sessionID)
+	if loaded != nil {
+		t.Error("expected state to be cleared")
+	}
+}
+
+func TestGetSettingsPath_Global(t *testing.T) {
+	path := getSettingsPath("/project", true)
+	if path == "" {
+		t.Error("expected non-empty path")
+	}
+	// Global path should contain home directory, not project
+	if filepath.Base(path) != "settings.json" {
+		t.Errorf("expected settings.json, got %s", filepath.Base(path))
+	}
+}
+
+func TestGetSettingsPath_Project(t *testing.T) {
+	path := getSettingsPath("/project", false)
+	if path == "" {
+		t.Error("expected non-empty path")
+	}
+	expected := "/project/.claude/settings.json"
+	if path != expected {
+		t.Errorf("expected %s, got %s", expected, path)
+	}
+}
+
+func TestHandler_IsInstalled_NotExists(t *testing.T) {
+	tmpDir := t.TempDir()
+	handler := NewHandler(nil)
+
+	installed, err := handler.IsInstalled(tmpDir, false)
+	if err != nil {
+		t.Fatalf("IsInstalled failed: %v", err)
+	}
+	if installed {
+		t.Error("expected not installed when settings file doesn't exist")
+	}
+}
+
+func TestHandler_IsInstalled_NoHooks(t *testing.T) {
+	tmpDir := t.TempDir()
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+		t.Fatalf("failed to create .claude dir: %v", err)
+	}
+
+	// Write settings without hooks
+	settings := `{"other_setting": true}`
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(settings), 0644); err != nil {
+		t.Fatalf("failed to write settings: %v", err)
+	}
+
+	handler := NewHandler(nil)
+	installed, err := handler.IsInstalled(tmpDir, false)
+	if err != nil {
+		t.Fatalf("IsInstalled failed: %v", err)
+	}
+	if installed {
+		t.Error("expected not installed when settings has no hooks")
+	}
+}
+
+func TestHandler_IsInstalled_WithHooks(t *testing.T) {
+	tmpDir := t.TempDir()
+	claudeDir := filepath.Join(tmpDir, ".claude")
+	if err := os.MkdirAll(claudeDir, 0755); err != nil {
+		t.Fatalf("failed to create .claude dir: %v", err)
+	}
+
+	// Write settings with hooks
+	settings := `{"hooks": {"SessionStart": {"command": "tin hook session-start"}}}`
+	if err := os.WriteFile(filepath.Join(claudeDir, "settings.json"), []byte(settings), 0644); err != nil {
+		t.Fatalf("failed to write settings: %v", err)
+	}
+
+	handler := NewHandler(nil)
+	installed, err := handler.IsInstalled(tmpDir, false)
+	if err != nil {
+		t.Fatalf("IsInstalled failed: %v", err)
+	}
+	if !installed {
+		t.Error("expected installed when settings has tin hooks")
+	}
+}

--- a/internal/agents/codex/handler.go
+++ b/internal/agents/codex/handler.go
@@ -1,0 +1,250 @@
+// Package codex provides the OpenAI Codex CLI agent integration for Tin.
+// It implements the NotifyHandler interface for notification-based tracking.
+//
+// Codex CLI only supports the "agent-turn-complete" notification event,
+// which provides limited real-time tracking compared to hook-based agents.
+package codex
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/dadlerj/tin/internal/agents"
+	"github.com/dadlerj/tin/internal/model"
+	"github.com/dadlerj/tin/internal/storage"
+)
+
+const (
+	agentName        = "codex"
+	agentDisplayName = "Codex CLI"
+	stateFileName    = ".tin-codex-session"
+)
+
+// Handler implements agents.NotifyHandler for Codex CLI
+type Handler struct {
+	config *agents.Config
+}
+
+// NewHandler creates a new Codex handler with the given config.
+func NewHandler(config *agents.Config) *Handler {
+	if config == nil {
+		config = agents.DefaultConfig()
+	}
+	return &Handler{config: config}
+}
+
+// Info returns metadata about the Codex agent
+func (h *Handler) Info() agents.AgentInfo {
+	return agents.AgentInfo{
+		Name:        agentName,
+		DisplayName: agentDisplayName,
+		Paradigm:    agents.ParadigmNotify,
+		Version:     "1.0.0",
+	}
+}
+
+// Setup configures notification handling for Codex.
+// This prints instructions for the user to configure their config.toml.
+func (h *Handler) Setup(projectDir string) error {
+	// Find tin binary path
+	tinPath, err := findTinBinary()
+	if err != nil {
+		return err
+	}
+
+	fmt.Println("To enable Codex CLI integration, add the following to your Codex config.toml:")
+	fmt.Println()
+	fmt.Printf("notify = [\"%s\", \"hook\", \"codex-notify\"]\n", tinPath)
+	fmt.Println()
+	fmt.Println("Config file locations:")
+	fmt.Println("  - macOS/Linux: ~/.codex/config.toml")
+	os.Stdout.WriteString("  - Windows: %USERPROFILE%\\.codex\\config.toml\n")
+	fmt.Println()
+	fmt.Println("After adding, Codex will notify tin when agent turns complete.")
+
+	return nil
+}
+
+// HandleNotification processes a notification event from Codex.
+// Codex sends a JSON payload as the first argument to the notify command.
+func (h *Handler) HandleNotification(event *agents.NotifyEvent) error {
+	// Parse Codex-specific payload
+	var payload CodexNotifyPayload
+	if err := json.Unmarshal(event.RawPayload, &payload); err != nil {
+		return fmt.Errorf("failed to parse Codex notification: %w", err)
+	}
+
+	// Only handle agent-turn-complete events
+	if payload.Type != "agent-turn-complete" {
+		return nil
+	}
+
+	repo, err := storage.Open(payload.Cwd)
+	if err != nil {
+		// Not a tin repo
+		return nil
+	}
+
+	// Try to load or create thread for this session
+	thread, err := h.getOrCreateThread(repo, payload.ThreadID)
+	if err != nil {
+		return err
+	}
+
+	// Add messages from the notification
+	for _, inputMsg := range payload.InputMessages {
+		msg := model.NewMessage(model.RoleHuman, inputMsg, "", nil)
+		thread.AddMessage(msg)
+	}
+
+	if payload.LastAssistantMessage != "" {
+		// Get current git hash
+		gitHash, _ := repo.GetCurrentGitHash()
+		msg := model.NewMessage(model.RoleAssistant, payload.LastAssistantMessage, "", nil)
+		msg.GitHashAfter = gitHash
+		thread.AddMessage(msg)
+	}
+
+	// Mark as complete since turn is done
+	thread.Complete()
+
+	// Auto-stage if configured
+	if h.config.AutoStage == nil || *h.config.AutoStage {
+		contentHash := thread.ComputeContentHash()
+		if err := repo.StageThread(thread.ID, len(thread.Messages), contentHash); err != nil {
+			return err
+		}
+	}
+
+	return repo.SaveThread(thread)
+}
+
+// SyncThread fetches and updates a specific thread by session ID.
+// For Codex, this is a no-op since we don't have access to session data
+// outside of notifications.
+func (h *Handler) SyncThread(sessionID string, cwd string) (*model.Thread, error) {
+	repo, err := storage.Open(cwd)
+	if err != nil {
+		return nil, err
+	}
+
+	threads, err := repo.FindThreadsBySessionID(sessionID)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(threads) == 0 {
+		return nil, fmt.Errorf("thread not found: %s", sessionID)
+	}
+
+	return threads[0], nil
+}
+
+func (h *Handler) getOrCreateThread(repo *storage.Repository, threadID string) (*model.Thread, error) {
+	// Check for existing thread
+	threads, _ := repo.FindThreadsBySessionID(threadID)
+	if len(threads) > 0 {
+		return threads[0], nil
+	}
+
+	// Create new thread
+	thread := model.NewThread(agentName, threadID, "", "")
+	thread.ID = fmt.Sprintf("codex-%s", threadID[:min(12, len(threadID))])
+
+	if err := repo.SaveThread(thread); err != nil {
+		return nil, err
+	}
+
+	return thread, nil
+}
+
+// CodexNotifyPayload represents the JSON payload sent by Codex CLI
+// on agent-turn-complete notifications.
+type CodexNotifyPayload struct {
+	Type                 string   `json:"type"`                   // "agent-turn-complete"
+	ThreadID             string   `json:"thread-id"`              // Session identifier
+	TurnID               string   `json:"turn-id"`                // Turn identifier
+	Cwd                  string   `json:"cwd"`                    // Working directory
+	InputMessages        []string `json:"input-messages"`         // User messages
+	LastAssistantMessage string   `json:"last-assistant-message"` // Assistant response
+}
+
+// ParseNotifyArgs parses the command-line argument from Codex notify command.
+// Codex passes a single JSON argument.
+func ParseNotifyArgs(args []string) (*agents.NotifyEvent, error) {
+	if len(args) < 1 {
+		return nil, fmt.Errorf("expected JSON argument")
+	}
+
+	var payload CodexNotifyPayload
+	if err := json.Unmarshal([]byte(args[0]), &payload); err != nil {
+		return nil, fmt.Errorf("failed to parse Codex notification: %w", err)
+	}
+
+	return &agents.NotifyEvent{
+		Type:       agents.NotifyEventTurnComplete,
+		SessionID:  payload.ThreadID,
+		Cwd:        payload.Cwd,
+		Timestamp:  time.Now().UTC(),
+		Message:    payload.LastAssistantMessage,
+		RawPayload: []byte(args[0]),
+	}, nil
+}
+
+// SessionState tracks the current session
+type SessionState struct {
+	SessionID string    `json:"session_id"`
+	ThreadID  string    `json:"thread_id"`
+	StartedAt time.Time `json:"started_at"`
+}
+
+func getSessionStatePath(rootPath, sessionID string) string {
+	shortID := sessionID
+	if len(shortID) > 12 {
+		shortID = shortID[:12]
+	}
+	return filepath.Join(rootPath, ".tin", fmt.Sprintf("%s-%s", stateFileName, shortID))
+}
+
+func findTinBinary() (string, error) {
+	// Try to find in PATH
+	path, err := findInPath("tin")
+	if err == nil {
+		return filepath.Abs(path)
+	}
+
+	// Try current executable
+	exe, err := os.Executable()
+	if err == nil {
+		return filepath.Abs(exe)
+	}
+
+	return "", fmt.Errorf("could not find tin binary")
+}
+
+func findInPath(name string) (string, error) {
+	pathEnv := os.Getenv("PATH")
+	for _, dir := range strings.Split(pathEnv, string(os.PathListSeparator)) {
+		path := filepath.Join(dir, name)
+		if _, err := os.Stat(path); err == nil {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("not found in PATH")
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// Register this handler with the global registry
+func init() {
+	agents.Register(NewHandler(nil))
+}

--- a/internal/agents/codex/handler_test.go
+++ b/internal/agents/codex/handler_test.go
@@ -1,0 +1,190 @@
+package codex
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/dadlerj/tin/internal/agents"
+)
+
+func TestHandler_Info(t *testing.T) {
+	handler := NewHandler(nil)
+	info := handler.Info()
+
+	if info.Name != "codex" {
+		t.Errorf("expected name 'codex', got %s", info.Name)
+	}
+	if info.DisplayName != "Codex CLI" {
+		t.Errorf("expected display name 'Codex CLI', got %s", info.DisplayName)
+	}
+	if info.Paradigm != agents.ParadigmNotify {
+		t.Errorf("expected paradigm Notify, got %v", info.Paradigm)
+	}
+}
+
+func TestHandler_NewWithNilConfig(t *testing.T) {
+	handler := NewHandler(nil)
+	if handler.config == nil {
+		t.Error("expected default config when nil is passed")
+	}
+}
+
+func TestHandler_NewWithConfig(t *testing.T) {
+	customTimeout := 60
+	config := &agents.Config{HookTimeout: customTimeout}
+	handler := NewHandler(config)
+
+	if handler.config.HookTimeout != customTimeout {
+		t.Errorf("expected custom timeout %d, got %d", customTimeout, handler.config.HookTimeout)
+	}
+}
+
+func TestParseNotifyArgs_Valid(t *testing.T) {
+	payload := CodexNotifyPayload{
+		Type:                 "agent-turn-complete",
+		ThreadID:             "thread-123",
+		TurnID:               "turn-456",
+		Cwd:                  "/project/path",
+		InputMessages:        []string{"Hello", "How are you?"},
+		LastAssistantMessage: "I'm doing well, thanks!",
+	}
+
+	data, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatalf("failed to marshal payload: %v", err)
+	}
+
+	event, err := ParseNotifyArgs([]string{string(data)})
+	if err != nil {
+		t.Fatalf("ParseNotifyArgs failed: %v", err)
+	}
+
+	if event.Type != agents.NotifyEventTurnComplete {
+		t.Errorf("expected type TurnComplete, got %v", event.Type)
+	}
+	if event.SessionID != "thread-123" {
+		t.Errorf("expected session ID 'thread-123', got %s", event.SessionID)
+	}
+	if event.Cwd != "/project/path" {
+		t.Errorf("expected cwd '/project/path', got %s", event.Cwd)
+	}
+	if event.Message != "I'm doing well, thanks!" {
+		t.Errorf("unexpected message: %s", event.Message)
+	}
+}
+
+func TestParseNotifyArgs_NoArgs(t *testing.T) {
+	_, err := ParseNotifyArgs([]string{})
+	if err == nil {
+		t.Error("expected error with no arguments")
+	}
+}
+
+func TestParseNotifyArgs_InvalidJSON(t *testing.T) {
+	_, err := ParseNotifyArgs([]string{"not valid json"})
+	if err == nil {
+		t.Error("expected error with invalid JSON")
+	}
+}
+
+func TestCodexNotifyPayload_JSONRoundtrip(t *testing.T) {
+	original := CodexNotifyPayload{
+		Type:                 "agent-turn-complete",
+		ThreadID:             "T-abc123",
+		TurnID:               "turn-xyz",
+		Cwd:                  "/home/user/project",
+		InputMessages:        []string{"First message", "Second message"},
+		LastAssistantMessage: "Response content",
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var decoded CodexNotifyPayload
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if decoded.Type != original.Type {
+		t.Errorf("Type mismatch: got %s, want %s", decoded.Type, original.Type)
+	}
+	if decoded.ThreadID != original.ThreadID {
+		t.Errorf("ThreadID mismatch: got %s, want %s", decoded.ThreadID, original.ThreadID)
+	}
+	if decoded.TurnID != original.TurnID {
+		t.Errorf("TurnID mismatch: got %s, want %s", decoded.TurnID, original.TurnID)
+	}
+	if decoded.Cwd != original.Cwd {
+		t.Errorf("Cwd mismatch: got %s, want %s", decoded.Cwd, original.Cwd)
+	}
+	if len(decoded.InputMessages) != len(original.InputMessages) {
+		t.Errorf("InputMessages length mismatch: got %d, want %d", len(decoded.InputMessages), len(original.InputMessages))
+	}
+	if decoded.LastAssistantMessage != original.LastAssistantMessage {
+		t.Errorf("LastAssistantMessage mismatch: got %s, want %s", decoded.LastAssistantMessage, original.LastAssistantMessage)
+	}
+}
+
+func TestSessionState_JSONRoundtrip(t *testing.T) {
+	original := SessionState{
+		SessionID: "sess-123",
+		ThreadID:  "thread-456",
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var decoded SessionState
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if decoded.SessionID != original.SessionID {
+		t.Errorf("SessionID mismatch: got %s, want %s", decoded.SessionID, original.SessionID)
+	}
+	if decoded.ThreadID != original.ThreadID {
+		t.Errorf("ThreadID mismatch: got %s, want %s", decoded.ThreadID, original.ThreadID)
+	}
+}
+
+func TestGetSessionStatePath(t *testing.T) {
+	tests := []struct {
+		rootPath  string
+		sessionID string
+		wantSuffix string
+	}{
+		{"/project", "abc123456789xyz", ".tin-codex-session-abc123456789"},
+		{"/project", "short", ".tin-codex-session-short"},
+		{"/project", "exactly12chr", ".tin-codex-session-exactly12chr"},
+	}
+
+	for _, tt := range tests {
+		got := getSessionStatePath(tt.rootPath, tt.sessionID)
+		if got != tt.rootPath+"/.tin/"+tt.wantSuffix {
+			t.Errorf("getSessionStatePath(%q, %q) = %q, want suffix %q", tt.rootPath, tt.sessionID, got, tt.wantSuffix)
+		}
+	}
+}
+
+func TestMin(t *testing.T) {
+	tests := []struct {
+		a, b, want int
+	}{
+		{1, 2, 1},
+		{2, 1, 1},
+		{5, 5, 5},
+		{0, 10, 0},
+		{-1, 1, -1},
+	}
+
+	for _, tt := range tests {
+		got := min(tt.a, tt.b)
+		if got != tt.want {
+			t.Errorf("min(%d, %d) = %d, want %d", tt.a, tt.b, got, tt.want)
+		}
+	}
+}

--- a/internal/agents/cursor/handler.go
+++ b/internal/agents/cursor/handler.go
@@ -1,0 +1,309 @@
+// Package cursor provides the Cursor IDE agent integration for Tin.
+// It implements the HookHandler interface for real-time thread tracking.
+package cursor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/dadlerj/tin/internal/agents"
+	"github.com/dadlerj/tin/internal/model"
+	"github.com/dadlerj/tin/internal/storage"
+)
+
+const (
+	agentName        = "cursor"
+	agentDisplayName = "Cursor"
+	stateFileName    = ".tin-cursor-session"
+	defaultTimeout   = 30
+)
+
+// Handler implements agents.HookHandler for Cursor
+type Handler struct {
+	config *agents.Config
+}
+
+// NewHandler creates a new Cursor handler with the given config.
+// If config is nil, default configuration is used.
+func NewHandler(config *agents.Config) *Handler {
+	if config == nil {
+		config = agents.DefaultConfig()
+	}
+	return &Handler{config: config}
+}
+
+// Info returns metadata about the Cursor agent
+func (h *Handler) Info() agents.AgentInfo {
+	return agents.AgentInfo{
+		Name:        agentName,
+		DisplayName: agentDisplayName,
+		Paradigm:    agents.ParadigmHook,
+		Version:     "1.0.0",
+	}
+}
+
+// Install configures hooks for Cursor
+func (h *Handler) Install(projectDir string, global bool) error {
+	return InstallHooks(projectDir, global, h.config.HookTimeout)
+}
+
+// Uninstall removes hooks for Cursor
+func (h *Handler) Uninstall(projectDir string, global bool) error {
+	return UninstallHooks(projectDir, global)
+}
+
+// IsInstalled checks if hooks are currently installed
+func (h *Handler) IsInstalled(projectDir string, global bool) (bool, error) {
+	hooksPath := getHooksPath(projectDir, global)
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, err
+	}
+	return strings.Contains(string(data), "tin hook"), nil
+}
+
+// HandleEvent processes a hook event from Cursor
+func (h *Handler) HandleEvent(event *agents.HookEvent) (string, error) {
+	repo, err := storage.Open(event.Cwd)
+	if err != nil {
+		// Not a tin repo - return empty string, no error (silent skip)
+		return "", nil
+	}
+
+	switch event.Type {
+	case agents.HookEventUserPrompt:
+		return h.handleUserPrompt(repo, event)
+	case agents.HookEventAssistantStop:
+		return h.handleStop(repo, event)
+	case agents.HookEventFileEdit:
+		return h.handleFileEdit(repo, event)
+	default:
+		// For unhandled events, just return without error
+		return "", nil
+	}
+}
+
+func (h *Handler) handleUserPrompt(repo *storage.Repository, event *agents.HookEvent) (string, error) {
+	if event.Prompt == "" {
+		return "", nil
+	}
+
+	// Try to load existing session state
+	state, _ := loadSessionState(repo.RootPath, event.SessionID)
+
+	var thread *model.Thread
+	var oldThreadID string
+
+	if state != nil {
+		// Load existing thread
+		var err error
+		thread, err = repo.LoadThread(state.ThreadID)
+		if err != nil {
+			// Thread not found, create new
+			thread = nil
+		} else {
+			oldThreadID = thread.ID
+		}
+	}
+
+	if thread == nil {
+		// Create new thread
+		thread = model.NewThread(agentName, event.SessionID, "", "")
+		thread.ID = fmt.Sprintf("cursor-%s", event.SessionID[:min(12, len(event.SessionID))])
+
+		// Save session state
+		if err := saveSessionState(repo.RootPath, event.SessionID, &SessionState{
+			SessionID: event.SessionID,
+			ThreadID:  thread.ID,
+			StartedAt: time.Now().UTC(),
+		}); err != nil {
+			return "", err
+		}
+	}
+
+	// Create human message
+	msg := model.NewMessage(model.RoleHuman, event.Prompt, "", nil)
+	thread.AddMessage(msg)
+
+	// Handle thread ID change
+	if oldThreadID != "" && thread.ID != oldThreadID {
+		if err := saveSessionState(repo.RootPath, event.SessionID, &SessionState{
+			SessionID: event.SessionID,
+			ThreadID:  thread.ID,
+			StartedAt: state.StartedAt,
+		}); err != nil {
+			return thread.ID, err
+		}
+		repo.DeleteThread(oldThreadID)
+		repo.UnstageThread(oldThreadID)
+	}
+
+	// Auto-stage if configured
+	if h.config.AutoStage == nil || *h.config.AutoStage {
+		contentHash := thread.ComputeContentHash()
+		if err := repo.StageThread(thread.ID, len(thread.Messages), contentHash); err != nil {
+			return thread.ID, err
+		}
+	}
+
+	return thread.ID, repo.SaveThread(thread)
+}
+
+func (h *Handler) handleStop(repo *storage.Repository, event *agents.HookEvent) (string, error) {
+	state, err := loadSessionState(repo.RootPath, event.SessionID)
+	if err != nil || state == nil {
+		return "", nil // No active session
+	}
+
+	thread, err := repo.LoadThread(state.ThreadID)
+	if err != nil {
+		return state.ThreadID, err
+	}
+
+	// Get assistant response from event
+	if event.Response == "" && len(event.ToolCalls) == 0 {
+		return state.ThreadID, nil // No response to record
+	}
+
+	// Get current git hash
+	gitHash, _ := repo.GetCurrentGitHash()
+
+	// Create assistant message
+	msg := model.NewMessage(model.RoleAssistant, event.Response, "", event.ToolCalls)
+	msg.GitHashAfter = gitHash
+	thread.AddMessage(msg)
+
+	// Mark as complete on stop
+	thread.Complete()
+
+	// Auto-commit git changes if configured
+	if h.config.AutoCommitGit == nil || *h.config.AutoCommitGit {
+		files, err := repo.GitGetChangedFiles()
+		if err == nil && len(files) > 0 {
+			if err := repo.GitAdd(files); err == nil {
+				hasChanges, err := repo.GitHasStagedChanges()
+				if err == nil && hasChanges {
+					commitMsg := formatGitCommitMessage(thread)
+					repo.GitCommit(commitMsg)
+				}
+			}
+		}
+	}
+
+	// Store git hash
+	thread.GitCommitHash, _ = repo.GetCurrentGitHash()
+
+	// Auto-stage if configured
+	if h.config.AutoStage == nil || *h.config.AutoStage {
+		contentHash := thread.ComputeContentHash()
+		if err := repo.StageThread(thread.ID, len(thread.Messages), contentHash); err != nil {
+			return thread.ID, err
+		}
+	}
+
+	// Clear session state
+	clearSessionState(repo.RootPath, event.SessionID)
+
+	return thread.ID, repo.SaveThread(thread)
+}
+
+func (h *Handler) handleFileEdit(repo *storage.Repository, event *agents.HookEvent) (string, error) {
+	// File edits are informational - we just note the git hash changed
+	state, _ := loadSessionState(repo.RootPath, event.SessionID)
+	if state == nil {
+		return "", nil
+	}
+
+	// The file edit is captured via git hash on the next message
+	return state.ThreadID, nil
+}
+
+// SessionState tracks the current session for hooks
+type SessionState struct {
+	SessionID string    `json:"session_id"`
+	ThreadID  string    `json:"thread_id"`
+	StartedAt time.Time `json:"started_at"`
+}
+
+func getSessionStatePath(rootPath, sessionID string) string {
+	shortID := sessionID
+	if len(shortID) > 12 {
+		shortID = shortID[:12]
+	}
+	return filepath.Join(rootPath, ".tin", fmt.Sprintf("%s-%s", stateFileName, shortID))
+}
+
+func loadSessionState(rootPath, sessionID string) (*SessionState, error) {
+	path := getSessionStatePath(rootPath, sessionID)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	var state SessionState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, err
+	}
+	return &state, nil
+}
+
+func saveSessionState(rootPath, sessionID string, state *SessionState) error {
+	path := getSessionStatePath(rootPath, sessionID)
+	data, err := json.Marshal(state)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, data, 0644)
+}
+
+func clearSessionState(rootPath, sessionID string) {
+	path := getSessionStatePath(rootPath, sessionID)
+	os.Remove(path)
+}
+
+func formatGitCommitMessage(thread *model.Thread) string {
+	shortID := thread.ID
+	if len(shortID) > 8 {
+		shortID = shortID[:8]
+	}
+
+	message := "thread completed"
+	if first := thread.FirstHumanMessage(); first != nil {
+		message = strings.TrimSpace(first.Content)
+	}
+
+	firstLine := message
+	restOfMessage := ""
+	if idx := strings.Index(message, "\n"); idx != -1 {
+		firstLine = strings.TrimSpace(message[:idx])
+		restOfMessage = strings.TrimSpace(message[idx+1:])
+	}
+
+	var builder strings.Builder
+	builder.WriteString(fmt.Sprintf("[tin %s] %s", shortID, firstLine))
+
+	if restOfMessage != "" {
+		builder.WriteString("\n\n")
+		builder.WriteString(restOfMessage)
+	}
+
+	return builder.String()
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// Register this handler with the global registry
+func init() {
+	agents.Register(NewHandler(nil))
+}

--- a/internal/agents/cursor/handler_test.go
+++ b/internal/agents/cursor/handler_test.go
@@ -1,0 +1,218 @@
+package cursor
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/dadlerj/tin/internal/agents"
+)
+
+func TestHandler_Info(t *testing.T) {
+	handler := NewHandler(nil)
+	info := handler.Info()
+
+	if info.Name != "cursor" {
+		t.Errorf("expected name 'cursor', got %s", info.Name)
+	}
+	if info.DisplayName != "Cursor" {
+		t.Errorf("expected display name 'Cursor', got %s", info.DisplayName)
+	}
+	if info.Paradigm != agents.ParadigmHook {
+		t.Errorf("expected paradigm Hook, got %v", info.Paradigm)
+	}
+}
+
+func TestHandler_NewWithNilConfig(t *testing.T) {
+	handler := NewHandler(nil)
+	if handler.config == nil {
+		t.Error("expected default config when nil is passed")
+	}
+}
+
+func TestHandler_NewWithConfig(t *testing.T) {
+	customTimeout := 60
+	config := &agents.Config{HookTimeout: customTimeout}
+	handler := NewHandler(config)
+
+	if handler.config.HookTimeout != customTimeout {
+		t.Errorf("expected custom timeout %d, got %d", customTimeout, handler.config.HookTimeout)
+	}
+}
+
+func TestSessionState_JSONRoundtrip(t *testing.T) {
+	original := SessionState{
+		SessionID: "conv-abc123",
+		ThreadID:  "thread-xyz789",
+	}
+
+	data, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var decoded SessionState
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if decoded.SessionID != original.SessionID {
+		t.Errorf("SessionID mismatch: got %s, want %s", decoded.SessionID, original.SessionID)
+	}
+	if decoded.ThreadID != original.ThreadID {
+		t.Errorf("ThreadID mismatch: got %s, want %s", decoded.ThreadID, original.ThreadID)
+	}
+}
+
+func TestGetHooksPath_Global(t *testing.T) {
+	path := getHooksPath("/project", true)
+	if path == "" {
+		t.Error("expected non-empty path")
+	}
+	// Global path should contain home directory, not project
+	if filepath.Base(path) != "hooks.json" {
+		t.Errorf("expected hooks.json, got %s", filepath.Base(path))
+	}
+}
+
+func TestGetHooksPath_Project(t *testing.T) {
+	path := getHooksPath("/project", false)
+	if path == "" {
+		t.Error("expected non-empty path")
+	}
+	expected := "/project/.cursor/hooks.json"
+	if path != expected {
+		t.Errorf("expected %s, got %s", expected, path)
+	}
+}
+
+func TestHandler_IsInstalled_NotExists(t *testing.T) {
+	tmpDir := t.TempDir()
+	handler := NewHandler(nil)
+
+	installed, err := handler.IsInstalled(tmpDir, false)
+	if err != nil {
+		t.Fatalf("IsInstalled failed: %v", err)
+	}
+	if installed {
+		t.Error("expected not installed when hooks file doesn't exist")
+	}
+}
+
+func TestHandler_IsInstalled_NoHooks(t *testing.T) {
+	tmpDir := t.TempDir()
+	cursorDir := filepath.Join(tmpDir, ".cursor")
+	if err := os.MkdirAll(cursorDir, 0755); err != nil {
+		t.Fatalf("failed to create .cursor dir: %v", err)
+	}
+
+	// Write hooks file without tin hooks
+	hooks := `{"hooks": [{"event": "stop", "command": "other-tool"}]}`
+	if err := os.WriteFile(filepath.Join(cursorDir, "hooks.json"), []byte(hooks), 0644); err != nil {
+		t.Fatalf("failed to write hooks: %v", err)
+	}
+
+	handler := NewHandler(nil)
+	installed, err := handler.IsInstalled(tmpDir, false)
+	if err != nil {
+		t.Fatalf("IsInstalled failed: %v", err)
+	}
+	if installed {
+		t.Error("expected not installed when hooks file has no tin hooks")
+	}
+}
+
+func TestHandler_IsInstalled_WithHooks(t *testing.T) {
+	tmpDir := t.TempDir()
+	cursorDir := filepath.Join(tmpDir, ".cursor")
+	if err := os.MkdirAll(cursorDir, 0755); err != nil {
+		t.Fatalf("failed to create .cursor dir: %v", err)
+	}
+
+	// Write hooks file with tin hooks
+	hooks := `{"hooks": [{"event": "stop", "command": "tin hook cursor-stop"}]}`
+	if err := os.WriteFile(filepath.Join(cursorDir, "hooks.json"), []byte(hooks), 0644); err != nil {
+		t.Fatalf("failed to write hooks: %v", err)
+	}
+
+	handler := NewHandler(nil)
+	installed, err := handler.IsInstalled(tmpDir, false)
+	if err != nil {
+		t.Fatalf("IsInstalled failed: %v", err)
+	}
+	if !installed {
+		t.Error("expected installed when hooks file has tin hooks")
+	}
+}
+
+func TestSaveAndLoadSessionState(t *testing.T) {
+	tmpDir := t.TempDir()
+	tinDir := filepath.Join(tmpDir, ".tin")
+	if err := os.MkdirAll(tinDir, 0755); err != nil {
+		t.Fatalf("failed to create .tin dir: %v", err)
+	}
+
+	sessionID := "test-session-id"
+	threadID := "test-thread-id"
+
+	// Save state
+	state := &SessionState{
+		SessionID: sessionID,
+		ThreadID:  threadID,
+	}
+	if err := saveSessionState(tmpDir, sessionID, state); err != nil {
+		t.Fatalf("saveSessionState failed: %v", err)
+	}
+
+	// Load state
+	loaded, err := loadSessionState(tmpDir, sessionID)
+	if err != nil {
+		t.Fatalf("loadSessionState failed: %v", err)
+	}
+	if loaded == nil {
+		t.Fatal("expected non-nil state")
+	}
+
+	if loaded.SessionID != sessionID {
+		t.Errorf("SessionID mismatch: got %s, want %s", loaded.SessionID, sessionID)
+	}
+	if loaded.ThreadID != threadID {
+		t.Errorf("ThreadID mismatch: got %s, want %s", loaded.ThreadID, threadID)
+	}
+}
+
+func TestLoadSessionState_NotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	tinDir := filepath.Join(tmpDir, ".tin")
+	if err := os.MkdirAll(tinDir, 0755); err != nil {
+		t.Fatalf("failed to create .tin dir: %v", err)
+	}
+
+	// loadSessionState returns error when session file not found
+	state, err := loadSessionState(tmpDir, "nonexistent-session")
+	if err == nil {
+		t.Error("expected error for nonexistent session file")
+	}
+	if state != nil {
+		t.Error("expected nil state for nonexistent session")
+	}
+}
+
+func TestGetSessionStatePath(t *testing.T) {
+	tests := []struct {
+		rootPath       string
+		conversationID string
+		wantContains   string
+	}{
+		{"/project", "abc123456789xyz", ".tin-cursor-session-abc123456789"},
+		{"/project", "short", ".tin-cursor-session-short"},
+	}
+
+	for _, tt := range tests {
+		got := getSessionStatePath(tt.rootPath, tt.conversationID)
+		if got == "" {
+			t.Errorf("expected non-empty path for %q, %q", tt.rootPath, tt.conversationID)
+		}
+	}
+}

--- a/internal/agents/cursor/install.go
+++ b/internal/agents/cursor/install.go
@@ -1,0 +1,188 @@
+package cursor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// CursorHooksConfig represents the Cursor hooks.json structure
+type CursorHooksConfig struct {
+	Version int                    `json:"version"`
+	Hooks   map[string][]HookEntry `json:"hooks"`
+}
+
+// HookEntry represents a single hook configuration
+type HookEntry struct {
+	Command string `json:"command"`
+}
+
+// getHooksPath returns the path to Cursor hooks.json
+func getHooksPath(projectDir string, global bool) string {
+	if global {
+		homeDir, _ := os.UserHomeDir()
+		return filepath.Join(homeDir, ".cursor", "hooks.json")
+	}
+	return filepath.Join(projectDir, ".cursor", "hooks.json")
+}
+
+// getGlobalHooksPath returns the enterprise/system-level hooks path
+func getGlobalHooksPath() string {
+	switch runtime.GOOS {
+	case "darwin":
+		return "/Library/Application Support/Cursor/hooks.json"
+	case "linux":
+		return "/etc/cursor/hooks.json"
+	case "windows":
+		return `C:\ProgramData\Cursor\hooks.json`
+	default:
+		return ""
+	}
+}
+
+// InstallHooks installs tin hooks into Cursor's hooks.json
+func InstallHooks(projectDir string, global bool, timeout int) error {
+	if timeout <= 0 {
+		timeout = defaultTimeout
+	}
+
+	// Find tin binary path
+	tinPath, err := findTinBinary()
+	if err != nil {
+		return err
+	}
+
+	hooksPath := getHooksPath(projectDir, global)
+
+	// Ensure directory exists
+	if err := os.MkdirAll(filepath.Dir(hooksPath), 0755); err != nil {
+		return err
+	}
+
+	// Load existing config or create new
+	config := &CursorHooksConfig{
+		Version: 1,
+		Hooks:   make(map[string][]HookEntry),
+	}
+
+	if data, err := os.ReadFile(hooksPath); err == nil {
+		if err := json.Unmarshal(data, config); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: Could not parse existing hooks.json, creating new\n")
+			config = &CursorHooksConfig{
+				Version: 1,
+				Hooks:   make(map[string][]HookEntry),
+			}
+		}
+	}
+
+	if config.Hooks == nil {
+		config.Hooks = make(map[string][]HookEntry)
+	}
+
+	// Define our hooks
+	// Cursor hook events we care about:
+	// - beforeSubmitPrompt: User submits a prompt
+	// - stop: Agent stops (completion)
+	// - afterFileEdit: File was edited (for tracking)
+	tinHooks := map[string]string{
+		"beforeSubmitPrompt": "cursor-prompt",
+		"stop":               "cursor-stop",
+		"afterFileEdit":      "cursor-file-edit",
+	}
+
+	for event, handler := range tinHooks {
+		hookCmd := fmt.Sprintf("%s hook %s", tinPath, handler)
+
+		// Check if hook already exists
+		existing := config.Hooks[event]
+		alreadyInstalled := false
+		for _, hook := range existing {
+			if strings.Contains(hook.Command, "tin hook") {
+				alreadyInstalled = true
+				break
+			}
+		}
+
+		if !alreadyInstalled {
+			config.Hooks[event] = append(config.Hooks[event], HookEntry{
+				Command: hookCmd,
+			})
+		}
+	}
+
+	// Write config
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(hooksPath, data, 0644)
+}
+
+// UninstallHooks removes tin hooks from Cursor's hooks.json
+func UninstallHooks(projectDir string, global bool) error {
+	hooksPath := getHooksPath(projectDir, global)
+
+	data, err := os.ReadFile(hooksPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // Nothing to uninstall
+		}
+		return err
+	}
+
+	var config CursorHooksConfig
+	if err := json.Unmarshal(data, &config); err != nil {
+		return err
+	}
+
+	if config.Hooks == nil {
+		return nil
+	}
+
+	// Remove tin hooks
+	events := []string{"beforeSubmitPrompt", "stop", "afterFileEdit"}
+	for _, event := range events {
+		hooks := config.Hooks[event]
+		var filtered []HookEntry
+		for _, hook := range hooks {
+			if !strings.Contains(hook.Command, "tin hook") {
+				filtered = append(filtered, hook)
+			}
+		}
+		if len(filtered) > 0 {
+			config.Hooks[event] = filtered
+		} else {
+			delete(config.Hooks, event)
+		}
+	}
+
+	// Write config
+	data, err = json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(hooksPath, data, 0644)
+}
+
+// findTinBinary finds the absolute path to the tin binary
+func findTinBinary() (string, error) {
+	// First, try to find in PATH
+	path, err := exec.LookPath("tin")
+	if err == nil {
+		return filepath.Abs(path)
+	}
+
+	// Try current executable
+	exe, err := os.Executable()
+	if err == nil {
+		return filepath.Abs(exe)
+	}
+
+	return "", fmt.Errorf("could not find tin binary. Make sure it's in your PATH")
+}

--- a/internal/agents/interfaces.go
+++ b/internal/agents/interfaces.go
@@ -1,0 +1,181 @@
+// Package agents provides interfaces and common types for integrating
+// various AI coding assistants with Tin's thread-based version control.
+//
+// There are three integration paradigms supported:
+//
+// 1. HookHandler - For agents with real-time hook support (Claude Code, Cursor)
+//    These agents call external commands at lifecycle events.
+//
+// 2. NotifyHandler - For agents with notification-only support (Codex CLI)
+//    These agents send limited event notifications that trigger syncs.
+//
+// 3. PullAdapter - For agents requiring pull-based sync (AMP, Copilot CLI)
+//    These agents don't support hooks; threads are fetched on demand.
+package agents
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/dadlerj/tin/internal/model"
+)
+
+// AgentInfo contains metadata about an agent integration
+type AgentInfo struct {
+	Name        string   // e.g., "claude-code", "cursor", "codex", "amp"
+	DisplayName string   // e.g., "Claude Code", "Cursor", "Codex CLI", "AMP"
+	Paradigm    Paradigm // hook, notify, or pull
+	Version     string   // Version of the integration
+}
+
+// Paradigm represents the integration pattern used by an agent
+type Paradigm string
+
+const (
+	ParadigmHook   Paradigm = "hook"   // Real-time hooks (push model)
+	ParadigmNotify Paradigm = "notify" // Notification + sync (hybrid model)
+	ParadigmPull   Paradigm = "pull"   // Pull/import (batch model)
+)
+
+// HookEvent represents a normalized event from hook-based agents
+type HookEvent struct {
+	Type        HookEventType   // Event type
+	SessionID   string          // Agent's session identifier
+	Cwd         string          // Working directory
+	Timestamp   time.Time       // When the event occurred
+	Prompt      string          // User prompt (for message events)
+	Response    string          // Assistant response (for response events)
+	ToolCalls   []model.ToolCall // Tool calls in response
+	Transcript  string          // Path to transcript file
+	RawPayload  json.RawMessage // Agent-specific raw data
+}
+
+// HookEventType enumerates the standard hook events
+type HookEventType string
+
+const (
+	HookEventSessionStart  HookEventType = "session_start"
+	HookEventUserPrompt    HookEventType = "user_prompt"
+	HookEventAssistantStop HookEventType = "assistant_stop"
+	HookEventSessionEnd    HookEventType = "session_end"
+	HookEventFileEdit      HookEventType = "file_edit"     // Cursor-specific
+	HookEventToolUse       HookEventType = "tool_use"      // Pre/post tool use
+)
+
+// NotifyEvent represents a notification from notification-based agents
+type NotifyEvent struct {
+	Type        NotifyEventType // Event type
+	SessionID   string          // Agent's session/thread identifier
+	Cwd         string          // Working directory
+	Timestamp   time.Time       // When the event occurred
+	Message     string          // Last assistant message (if available)
+	RawPayload  json.RawMessage // Agent-specific raw data
+}
+
+// NotifyEventType enumerates notification event types
+type NotifyEventType string
+
+const (
+	NotifyEventTurnComplete NotifyEventType = "turn_complete" // Agent finished a turn
+)
+
+// PullOptions configures how threads are pulled from an agent
+type PullOptions struct {
+	Count      int    // Number of threads to pull (0 = all available)
+	ThreadID   string // Specific thread ID to pull
+	Since      *time.Time // Only pull threads updated since this time
+	IncludeGit bool   // Record current git hash on pulled threads
+}
+
+// HookHandler defines the interface for agents with full hook support.
+// These agents call Tin at lifecycle events, enabling real-time tracking.
+//
+// Examples: Claude Code, Cursor
+type HookHandler interface {
+	// Info returns metadata about this agent
+	Info() AgentInfo
+
+	// Install configures hooks for this agent.
+	// If global is true, installs to user-level config (~/.agent/);
+	// otherwise installs to project-level (.agent/).
+	Install(projectDir string, global bool) error
+
+	// Uninstall removes hooks for this agent.
+	Uninstall(projectDir string, global bool) error
+
+	// IsInstalled checks if hooks are currently installed.
+	IsInstalled(projectDir string, global bool) (bool, error)
+
+	// HandleEvent processes a hook event and updates the thread.
+	// Returns the thread ID that was created/updated, or error.
+	HandleEvent(event *HookEvent) (string, error)
+}
+
+// NotifyHandler defines the interface for agents with notification support.
+// These agents send limited events that trigger Tin to sync thread data.
+//
+// Examples: Codex CLI
+type NotifyHandler interface {
+	// Info returns metadata about this agent
+	Info() AgentInfo
+
+	// Setup configures notification handling for this agent.
+	// This may involve outputting config instructions for the user.
+	Setup(projectDir string) error
+
+	// HandleNotification processes a notification event.
+	// This typically triggers a sync of the affected thread.
+	HandleNotification(event *NotifyEvent) error
+
+	// SyncThread fetches and updates a specific thread by session ID.
+	SyncThread(sessionID string, cwd string) (*model.Thread, error)
+}
+
+// PullAdapter defines the interface for agents requiring pull-based sync.
+// These agents don't support hooks; threads are fetched on demand.
+//
+// Examples: AMP, GitHub Copilot CLI
+type PullAdapter interface {
+	// Info returns metadata about this agent
+	Info() AgentInfo
+
+	// List returns available thread IDs from the agent.
+	List(limit int) ([]string, error)
+
+	// Pull fetches a specific thread by ID.
+	Pull(threadID string, opts PullOptions) (*model.Thread, error)
+
+	// PullRecent fetches the N most recent threads.
+	PullRecent(count int, opts PullOptions) ([]*model.Thread, error)
+}
+
+// Config holds agent-specific configuration
+type Config struct {
+	// HookTimeout is the timeout for hook execution in seconds.
+	// Default is 30 seconds if not specified.
+	HookTimeout int `json:"hook_timeout,omitempty"`
+
+	// AutoStage automatically stages threads after updates.
+	// Default is true.
+	AutoStage *bool `json:"auto_stage,omitempty"`
+
+	// AutoCommitGit automatically commits git changes on session end.
+	// Default is true for hook-based agents.
+	AutoCommitGit *bool `json:"auto_commit_git,omitempty"`
+
+	// PollInterval is the interval for daemon polling in seconds.
+	// Only applicable to pull-based agents with daemon mode.
+	PollInterval int `json:"poll_interval,omitempty"`
+}
+
+// DefaultConfig returns the default agent configuration
+func DefaultConfig() *Config {
+	autoStage := true
+	autoCommit := true
+	return &Config{
+		HookTimeout:   30,
+		AutoStage:     &autoStage,
+		AutoCommitGit: &autoCommit,
+		PollInterval:  60,
+	}
+}

--- a/internal/agents/registry.go
+++ b/internal/agents/registry.go
@@ -1,0 +1,159 @@
+package agents
+
+import (
+	"fmt"
+	"sync"
+)
+
+// Registry manages registered agent integrations
+type Registry struct {
+	mu            sync.RWMutex
+	hookHandlers  map[string]HookHandler
+	notifyHandlers map[string]NotifyHandler
+	pullAdapters  map[string]PullAdapter
+}
+
+// globalRegistry is the default registry instance
+var globalRegistry = NewRegistry()
+
+// NewRegistry creates a new agent registry
+func NewRegistry() *Registry {
+	return &Registry{
+		hookHandlers:   make(map[string]HookHandler),
+		notifyHandlers: make(map[string]NotifyHandler),
+		pullAdapters:   make(map[string]PullAdapter),
+	}
+}
+
+// RegisterHookHandler registers a hook-based agent handler
+func (r *Registry) RegisterHookHandler(name string, handler HookHandler) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.hookHandlers[name] = handler
+}
+
+// RegisterNotifyHandler registers a notification-based agent handler
+func (r *Registry) RegisterNotifyHandler(name string, handler NotifyHandler) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.notifyHandlers[name] = handler
+}
+
+// RegisterPullAdapter registers a pull-based agent adapter
+func (r *Registry) RegisterPullAdapter(name string, adapter PullAdapter) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.pullAdapters[name] = adapter
+}
+
+// GetHookHandler returns a hook handler by name
+func (r *Registry) GetHookHandler(name string) (HookHandler, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	h, ok := r.hookHandlers[name]
+	return h, ok
+}
+
+// GetNotifyHandler returns a notify handler by name
+func (r *Registry) GetNotifyHandler(name string) (NotifyHandler, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	h, ok := r.notifyHandlers[name]
+	return h, ok
+}
+
+// GetPullAdapter returns a pull adapter by name
+func (r *Registry) GetPullAdapter(name string) (PullAdapter, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	a, ok := r.pullAdapters[name]
+	return a, ok
+}
+
+// ListHookHandlers returns all registered hook handler names
+func (r *Registry) ListHookHandlers() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.hookHandlers))
+	for name := range r.hookHandlers {
+		names = append(names, name)
+	}
+	return names
+}
+
+// ListNotifyHandlers returns all registered notify handler names
+func (r *Registry) ListNotifyHandlers() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.notifyHandlers))
+	for name := range r.notifyHandlers {
+		names = append(names, name)
+	}
+	return names
+}
+
+// ListPullAdapters returns all registered pull adapter names
+func (r *Registry) ListPullAdapters() []string {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	names := make([]string, 0, len(r.pullAdapters))
+	for name := range r.pullAdapters {
+		names = append(names, name)
+	}
+	return names
+}
+
+// ListAll returns info about all registered agents
+func (r *Registry) ListAll() []AgentInfo {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+
+	var infos []AgentInfo
+	for _, h := range r.hookHandlers {
+		infos = append(infos, h.Info())
+	}
+	for _, h := range r.notifyHandlers {
+		infos = append(infos, h.Info())
+	}
+	for _, a := range r.pullAdapters {
+		infos = append(infos, a.Info())
+	}
+	return infos
+}
+
+// Global registry functions for convenience
+
+// Register registers a handler/adapter with the global registry
+func Register(handler interface{}) error {
+	switch h := handler.(type) {
+	case HookHandler:
+		globalRegistry.RegisterHookHandler(h.Info().Name, h)
+	case NotifyHandler:
+		globalRegistry.RegisterNotifyHandler(h.Info().Name, h)
+	case PullAdapter:
+		globalRegistry.RegisterPullAdapter(h.Info().Name, h)
+	default:
+		return fmt.Errorf("unknown handler type: %T", handler)
+	}
+	return nil
+}
+
+// GetHook returns a hook handler from the global registry
+func GetHook(name string) (HookHandler, bool) {
+	return globalRegistry.GetHookHandler(name)
+}
+
+// GetNotify returns a notify handler from the global registry
+func GetNotify(name string) (NotifyHandler, bool) {
+	return globalRegistry.GetNotifyHandler(name)
+}
+
+// GetPull returns a pull adapter from the global registry
+func GetPull(name string) (PullAdapter, bool) {
+	return globalRegistry.GetPullAdapter(name)
+}
+
+// List returns all registered agent infos from the global registry
+func List() []AgentInfo {
+	return globalRegistry.ListAll()
+}

--- a/internal/agents/registry_test.go
+++ b/internal/agents/registry_test.go
@@ -1,0 +1,227 @@
+package agents
+
+import (
+	"testing"
+
+	"github.com/dadlerj/tin/internal/model"
+)
+
+// Mock implementations for testing
+
+type mockHookHandler struct {
+	name string
+}
+
+func (m *mockHookHandler) Info() AgentInfo {
+	return AgentInfo{Name: m.name, DisplayName: m.name, Paradigm: ParadigmHook}
+}
+func (m *mockHookHandler) Install(projectDir string, global bool) error             { return nil }
+func (m *mockHookHandler) Uninstall(projectDir string, global bool) error           { return nil }
+func (m *mockHookHandler) IsInstalled(projectDir string, global bool) (bool, error) { return false, nil }
+func (m *mockHookHandler) HandleEvent(event *HookEvent) (string, error)             { return "", nil }
+
+type mockNotifyHandler struct {
+	name string
+}
+
+func (m *mockNotifyHandler) Info() AgentInfo {
+	return AgentInfo{Name: m.name, DisplayName: m.name, Paradigm: ParadigmNotify}
+}
+func (m *mockNotifyHandler) Setup(projectDir string) error                                 { return nil }
+func (m *mockNotifyHandler) HandleNotification(event *NotifyEvent) error                   { return nil }
+func (m *mockNotifyHandler) SyncThread(sessionID string, cwd string) (*model.Thread, error) { return nil, nil }
+
+type mockPullAdapter struct {
+	name string
+}
+
+func (m *mockPullAdapter) Info() AgentInfo {
+	return AgentInfo{Name: m.name, DisplayName: m.name, Paradigm: ParadigmPull}
+}
+func (m *mockPullAdapter) List(limit int) ([]string, error) { return nil, nil }
+func (m *mockPullAdapter) Pull(threadID string, opts PullOptions) (*model.Thread, error) {
+	return nil, nil
+}
+func (m *mockPullAdapter) PullRecent(count int, opts PullOptions) ([]*model.Thread, error) {
+	return nil, nil
+}
+
+func TestRegistry_RegisterAndGetHook(t *testing.T) {
+	reg := NewRegistry()
+
+	handler := &mockHookHandler{name: "test-hook"}
+	reg.RegisterHookHandler("test-hook", handler)
+
+	got, ok := reg.GetHookHandler("test-hook")
+	if !ok {
+		t.Fatal("expected to find registered hook handler")
+	}
+	if got.Info().Name != "test-hook" {
+		t.Errorf("expected name 'test-hook', got %s", got.Info().Name)
+	}
+}
+
+func TestRegistry_RegisterAndGetNotify(t *testing.T) {
+	reg := NewRegistry()
+
+	handler := &mockNotifyHandler{name: "test-notify"}
+	reg.RegisterNotifyHandler("test-notify", handler)
+
+	got, ok := reg.GetNotifyHandler("test-notify")
+	if !ok {
+		t.Fatal("expected to find registered notify handler")
+	}
+	if got.Info().Name != "test-notify" {
+		t.Errorf("expected name 'test-notify', got %s", got.Info().Name)
+	}
+}
+
+func TestRegistry_RegisterAndGetPull(t *testing.T) {
+	reg := NewRegistry()
+
+	adapter := &mockPullAdapter{name: "test-pull"}
+	reg.RegisterPullAdapter("test-pull", adapter)
+
+	got, ok := reg.GetPullAdapter("test-pull")
+	if !ok {
+		t.Fatal("expected to find registered pull adapter")
+	}
+	if got.Info().Name != "test-pull" {
+		t.Errorf("expected name 'test-pull', got %s", got.Info().Name)
+	}
+}
+
+func TestRegistry_GetNonExistent(t *testing.T) {
+	reg := NewRegistry()
+
+	_, ok := reg.GetHookHandler("nonexistent")
+	if ok {
+		t.Error("expected not to find nonexistent hook handler")
+	}
+
+	_, ok = reg.GetNotifyHandler("nonexistent")
+	if ok {
+		t.Error("expected not to find nonexistent notify handler")
+	}
+
+	_, ok = reg.GetPullAdapter("nonexistent")
+	if ok {
+		t.Error("expected not to find nonexistent pull adapter")
+	}
+}
+
+func TestRegistry_ListAll(t *testing.T) {
+	reg := NewRegistry()
+
+	reg.RegisterHookHandler("hook1", &mockHookHandler{name: "hook1"})
+	reg.RegisterHookHandler("hook2", &mockHookHandler{name: "hook2"})
+	reg.RegisterNotifyHandler("notify1", &mockNotifyHandler{name: "notify1"})
+	reg.RegisterPullAdapter("pull1", &mockPullAdapter{name: "pull1"})
+
+	all := reg.ListAll()
+	if len(all) != 4 {
+		t.Errorf("expected 4 registered agents, got %d", len(all))
+	}
+
+	// Verify each type is represented
+	paradigms := make(map[Paradigm]int)
+	for _, info := range all {
+		paradigms[info.Paradigm]++
+	}
+
+	if paradigms[ParadigmHook] != 2 {
+		t.Errorf("expected 2 hook agents, got %d", paradigms[ParadigmHook])
+	}
+	if paradigms[ParadigmNotify] != 1 {
+		t.Errorf("expected 1 notify agent, got %d", paradigms[ParadigmNotify])
+	}
+	if paradigms[ParadigmPull] != 1 {
+		t.Errorf("expected 1 pull agent, got %d", paradigms[ParadigmPull])
+	}
+}
+
+func TestRegistry_ListHookHandlers(t *testing.T) {
+	reg := NewRegistry()
+
+	reg.RegisterHookHandler("hook1", &mockHookHandler{name: "hook1"})
+	reg.RegisterHookHandler("hook2", &mockHookHandler{name: "hook2"})
+	reg.RegisterNotifyHandler("notify1", &mockNotifyHandler{name: "notify1"})
+
+	hooks := reg.ListHookHandlers()
+	if len(hooks) != 2 {
+		t.Errorf("expected 2 hook handlers, got %d", len(hooks))
+	}
+}
+
+func TestRegistry_ListNotifyHandlers(t *testing.T) {
+	reg := NewRegistry()
+
+	reg.RegisterNotifyHandler("notify1", &mockNotifyHandler{name: "notify1"})
+	reg.RegisterNotifyHandler("notify2", &mockNotifyHandler{name: "notify2"})
+
+	notifies := reg.ListNotifyHandlers()
+	if len(notifies) != 2 {
+		t.Errorf("expected 2 notify handlers, got %d", len(notifies))
+	}
+}
+
+func TestRegistry_ListPullAdapters(t *testing.T) {
+	reg := NewRegistry()
+
+	reg.RegisterPullAdapter("pull1", &mockPullAdapter{name: "pull1"})
+
+	adapters := reg.ListPullAdapters()
+	if len(adapters) != 1 {
+		t.Errorf("expected 1 pull adapter, got %d", len(adapters))
+	}
+}
+
+func TestDefaultConfig(t *testing.T) {
+	config := DefaultConfig()
+
+	if config.AutoStage == nil {
+		t.Fatal("expected AutoStage to be set")
+	}
+	if !*config.AutoStage {
+		t.Error("expected AutoStage to default to true")
+	}
+
+	if config.AutoCommitGit == nil {
+		t.Fatal("expected AutoCommitGit to be set")
+	}
+	if !*config.AutoCommitGit {
+		t.Error("expected AutoCommitGit to default to true")
+	}
+
+	if config.HookTimeout != 30 {
+		t.Errorf("expected HookTimeout to be 30, got %d", config.HookTimeout)
+	}
+
+	if config.PollInterval != 60 {
+		t.Errorf("expected PollInterval to be 60, got %d", config.PollInterval)
+	}
+}
+
+func TestGlobalRegister(t *testing.T) {
+	// Test the global Register function with different types
+	err := Register(&mockHookHandler{name: "global-hook"})
+	if err != nil {
+		t.Errorf("expected no error registering hook handler, got %v", err)
+	}
+
+	err = Register(&mockNotifyHandler{name: "global-notify"})
+	if err != nil {
+		t.Errorf("expected no error registering notify handler, got %v", err)
+	}
+
+	err = Register(&mockPullAdapter{name: "global-pull"})
+	if err != nil {
+		t.Errorf("expected no error registering pull adapter, got %v", err)
+	}
+
+	// Test registering invalid type
+	err = Register("invalid")
+	if err == nil {
+		t.Error("expected error registering invalid type")
+	}
+}

--- a/internal/commands/agents.go
+++ b/internal/commands/agents.go
@@ -1,0 +1,300 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/dadlerj/tin/internal/agents"
+	// Import agent packages to trigger their init() registration
+	_ "github.com/dadlerj/tin/internal/agents/amp"
+	_ "github.com/dadlerj/tin/internal/agents/claudecode"
+	_ "github.com/dadlerj/tin/internal/agents/codex"
+	_ "github.com/dadlerj/tin/internal/agents/cursor"
+)
+
+// Agents handles the "tin agents" command
+func Agents(args []string) error {
+	if len(args) == 0 {
+		printAgentsHelp()
+		return nil
+	}
+
+	subcmd := args[0]
+	subargs := args[1:]
+
+	switch subcmd {
+	case "list":
+		return agentsList()
+	case "status":
+		return agentsStatus(subargs)
+	case "-h", "--help":
+		printAgentsHelp()
+		return nil
+	default:
+		return fmt.Errorf("unknown agents subcommand: %s", subcmd)
+	}
+}
+
+func agentsList() error {
+	infos := agents.List()
+
+	if len(infos) == 0 {
+		fmt.Println("No agents registered")
+		return nil
+	}
+
+	fmt.Println("Registered agents:")
+	fmt.Println()
+
+	// Group by paradigm
+	hookAgents := []agents.AgentInfo{}
+	notifyAgents := []agents.AgentInfo{}
+	pullAgents := []agents.AgentInfo{}
+
+	for _, info := range infos {
+		switch info.Paradigm {
+		case agents.ParadigmHook:
+			hookAgents = append(hookAgents, info)
+		case agents.ParadigmNotify:
+			notifyAgents = append(notifyAgents, info)
+		case agents.ParadigmPull:
+			pullAgents = append(pullAgents, info)
+		}
+	}
+
+	if len(hookAgents) > 0 {
+		fmt.Println("Hook-based (real-time tracking):")
+		for _, info := range hookAgents {
+			status := getAgentStatus(info.Name)
+			fmt.Printf("  %-15s %s %s\n", info.Name, info.DisplayName, status)
+		}
+		fmt.Println()
+	}
+
+	if len(notifyAgents) > 0 {
+		fmt.Println("Notification-based (partial tracking):")
+		for _, info := range notifyAgents {
+			status := getAgentStatus(info.Name)
+			fmt.Printf("  %-15s %s %s\n", info.Name, info.DisplayName, status)
+		}
+		fmt.Println()
+	}
+
+	if len(pullAgents) > 0 {
+		fmt.Println("Pull-based (manual sync):")
+		for _, info := range pullAgents {
+			fmt.Printf("  %-15s %s\n", info.Name, info.DisplayName)
+		}
+		fmt.Println()
+	}
+
+	return nil
+}
+
+func getAgentStatus(name string) string {
+	cwd, _ := os.Getwd()
+
+	// Check if hooks are installed for hook-based agents
+	if handler, ok := agents.GetHook(name); ok {
+		installed, _ := handler.IsInstalled(cwd, false)
+		globalInstalled, _ := handler.IsInstalled(cwd, true)
+		if installed {
+			return "(hooks installed: project)"
+		}
+		if globalInstalled {
+			return "(hooks installed: global)"
+		}
+		return "(not installed)"
+	}
+
+	return ""
+}
+
+func agentsStatus(args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	fmt.Printf("Agent status in: %s\n\n", cwd)
+
+	infos := agents.List()
+
+	for _, info := range infos {
+		fmt.Printf("%s (%s):\n", info.DisplayName, info.Paradigm)
+
+		switch info.Paradigm {
+		case agents.ParadigmHook:
+			handler, _ := agents.GetHook(info.Name)
+			if handler != nil {
+				projectInstalled, _ := handler.IsInstalled(cwd, false)
+				globalInstalled, _ := handler.IsInstalled(cwd, true)
+
+				if projectInstalled {
+					fmt.Println("  Hooks: installed (project-level)")
+				} else if globalInstalled {
+					fmt.Println("  Hooks: installed (global)")
+				} else {
+					fmt.Println("  Hooks: not installed")
+				}
+			}
+
+		case agents.ParadigmNotify:
+			fmt.Println("  Status: requires manual config.toml setup")
+			fmt.Printf("  Run 'tin %s setup' for instructions\n", info.Name)
+
+		case agents.ParadigmPull:
+			fmt.Println("  Status: pull-based (use 'tin amp pull' to sync)")
+		}
+		fmt.Println()
+	}
+
+	return nil
+}
+
+// HooksInstall handles "tin hooks install" with multi-agent support
+func HooksInstall(args []string, global bool) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	// Parse which agents to install
+	agentNames := []string{}
+	installAll := false
+
+	for _, arg := range args {
+		switch arg {
+		case "--all":
+			installAll = true
+		case "--claude-code", "--claudecode":
+			agentNames = append(agentNames, "claude-code")
+		case "--cursor":
+			agentNames = append(agentNames, "cursor")
+		case "--codex":
+			// Codex doesn't use hooks, print instructions instead
+			if handler, ok := agents.GetNotify("codex"); ok {
+				handler.Setup(cwd)
+			}
+		default:
+			if strings.HasPrefix(arg, "--") {
+				return fmt.Errorf("unknown agent: %s", arg)
+			}
+		}
+	}
+
+	// Default to claude-code if no agents specified
+	if len(agentNames) == 0 && !installAll {
+		agentNames = []string{"claude-code"}
+	}
+
+	// Install all hook-based agents if --all
+	if installAll {
+		for _, name := range agents.List() {
+			if name.Paradigm == agents.ParadigmHook {
+				agentNames = append(agentNames, name.Name)
+			}
+		}
+	}
+
+	// Install hooks for each agent
+	for _, name := range agentNames {
+		handler, ok := agents.GetHook(name)
+		if !ok {
+			fmt.Fprintf(os.Stderr, "Warning: %s is not a hook-based agent, skipping\n", name)
+			continue
+		}
+
+		if err := handler.Install(cwd, global); err != nil {
+			return fmt.Errorf("failed to install %s hooks: %w", name, err)
+		}
+
+		scope := "project"
+		if global {
+			scope = "global"
+		}
+		fmt.Printf("Installed %s hooks (%s)\n", handler.Info().DisplayName, scope)
+	}
+
+	return nil
+}
+
+// HooksUninstall handles "tin hooks uninstall" with multi-agent support
+func HooksUninstall(args []string, global bool) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	// Parse which agents to uninstall
+	agentNames := []string{}
+	uninstallAll := false
+
+	for _, arg := range args {
+		switch arg {
+		case "--all":
+			uninstallAll = true
+		case "--claude-code", "--claudecode":
+			agentNames = append(agentNames, "claude-code")
+		case "--cursor":
+			agentNames = append(agentNames, "cursor")
+		default:
+			if strings.HasPrefix(arg, "--") {
+				return fmt.Errorf("unknown agent: %s", arg)
+			}
+		}
+	}
+
+	// Default to claude-code if no agents specified
+	if len(agentNames) == 0 && !uninstallAll {
+		agentNames = []string{"claude-code"}
+	}
+
+	// Uninstall all hook-based agents if --all
+	if uninstallAll {
+		for _, name := range agents.List() {
+			if name.Paradigm == agents.ParadigmHook {
+				agentNames = append(agentNames, name.Name)
+			}
+		}
+	}
+
+	// Uninstall hooks for each agent
+	for _, name := range agentNames {
+		handler, ok := agents.GetHook(name)
+		if !ok {
+			continue // Skip non-hook agents silently
+		}
+
+		if err := handler.Uninstall(cwd, global); err != nil {
+			return fmt.Errorf("failed to uninstall %s hooks: %w", name, err)
+		}
+
+		scope := "project"
+		if global {
+			scope = "global"
+		}
+		fmt.Printf("Uninstalled %s hooks (%s)\n", handler.Info().DisplayName, scope)
+	}
+
+	return nil
+}
+
+func printAgentsHelp() {
+	fmt.Println(`Manage agent integrations
+
+Usage: tin agents <command>
+
+Commands:
+  list      List all registered agents
+  status    Show agent status in current directory
+
+Agent Types:
+  Hook-based (real-time):     claude-code, cursor
+  Notification-based:         codex
+  Pull-based (manual sync):   amp
+
+Use "tin hooks install --<agent>" to install hooks for specific agents.
+Use "tin <agent> pull" for pull-based agents.`)
+}

--- a/internal/commands/amp.go
+++ b/internal/commands/amp.go
@@ -325,7 +325,7 @@ func parseAmpMarkdown(markdown string, ampThreadID string) (*model.Thread, error
 					argsBytes = []byte(argsStr)
 				} else {
 					// Invalid JSON - store empty object with tool name hint
-					argsBytes = []byte(fmt.Sprintf(`{"_raw": "parse error"}`, toolName))
+					argsBytes = []byte(`{"_raw": "parse error"}`)
 				}
 			} else {
 				// Not JSON - store as empty

--- a/internal/commands/codex.go
+++ b/internal/commands/codex.go
@@ -1,0 +1,59 @@
+package commands
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/dadlerj/tin/internal/agents"
+	_ "github.com/dadlerj/tin/internal/agents/codex" // Register agent
+)
+
+// Codex handles the "tin codex" command
+func Codex(args []string) error {
+	if len(args) == 0 {
+		printCodexHelp()
+		return nil
+	}
+
+	subcmd := args[0]
+
+	switch subcmd {
+	case "setup":
+		return codexSetup()
+	case "-h", "--help":
+		printCodexHelp()
+		return nil
+	default:
+		return fmt.Errorf("unknown codex subcommand: %s", subcmd)
+	}
+}
+
+func codexSetup() error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	handler, ok := agents.GetNotify("codex")
+	if !ok {
+		return fmt.Errorf("codex agent not registered")
+	}
+
+	return handler.Setup(cwd)
+}
+
+func printCodexHelp() {
+	fmt.Println(`Manage Codex CLI (OpenAI) agent integration
+
+Usage: tin codex <command>
+
+Commands:
+  setup    Show configuration instructions for Codex CLI
+
+Codex CLI uses a notification-based integration, which requires manual
+configuration of your config.toml file. Run 'tin codex setup' for
+detailed instructions.
+
+Note: Codex only supports the 'agent-turn-complete' notification event,
+so thread tracking is less comprehensive than hook-based agents.`)
+}

--- a/internal/commands/config.go
+++ b/internal/commands/config.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"strings"
 
+	"github.com/dadlerj/tin/internal/remote"
 	"github.com/dadlerj/tin/internal/storage"
 )
 
@@ -12,6 +13,7 @@ import (
 var configKeys = map[string]string{
 	"thread_host_url": "Base URL for tin web viewer (e.g., http://localhost:8080)",
 	"code_host_url":   "URL for code repository (e.g., https://github.com/user/repo)",
+	"auth_token":      "Authentication token for remote operations (th_xxx)",
 }
 
 func Config(args []string) error {
@@ -29,6 +31,8 @@ func Config(args []string) error {
 		return configGet(args[1:])
 	case "set":
 		return configSet(args[1:])
+	case "credentials":
+		return configCredentials(args[1:])
 	default:
 		return fmt.Errorf("unknown config subcommand: %s", args[0])
 	}
@@ -58,6 +62,11 @@ func configList() error {
 
 	if config.CodeHostURL != "" {
 		fmt.Printf("code_host_url = %s\n", config.CodeHostURL)
+	}
+
+	if config.AuthToken != "" {
+		// Mask the token for display
+		fmt.Printf("auth_token = %s***\n", config.AuthToken[:min(6, len(config.AuthToken))])
 	}
 
 	if len(config.Remotes) > 0 {
@@ -101,6 +110,10 @@ func configGet(args []string) error {
 		if config.CodeHostURL != "" {
 			fmt.Println(config.CodeHostURL)
 		}
+	case "auth_token":
+		if config.AuthToken != "" {
+			fmt.Println(config.AuthToken)
+		}
 	case "version":
 		fmt.Println(config.Version)
 	default:
@@ -139,6 +152,8 @@ func configSet(args []string) error {
 		config.ThreadHostURL = strings.TrimSuffix(value, "/")
 	case "code_host_url":
 		config.CodeHostURL = strings.TrimSuffix(value, "/")
+	case "auth_token":
+		config.AuthToken = value
 	default:
 		return fmt.Errorf("unknown config key: %s\n\nAvailable keys:\n%s", key, formatAvailableKeys())
 	}
@@ -159,22 +174,113 @@ func formatAvailableKeys() string {
 	return strings.Join(lines, "\n")
 }
 
+// configCredentials handles credential management subcommands
+func configCredentials(args []string) error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return err
+	}
+
+	repo, err := storage.Open(cwd)
+	if err != nil {
+		return err
+	}
+
+	credStore := remote.NewCredentialStore(repo.RootPath)
+
+	if len(args) == 0 {
+		// List credentials
+		return credentialsList(repo)
+	}
+
+	switch args[0] {
+	case "add":
+		if len(args) < 3 {
+			return fmt.Errorf("usage: tin config credentials add <host> <token>")
+		}
+		host := args[1]
+		token := args[2]
+		if err := credStore.Store(host, token); err != nil {
+			return err
+		}
+		fmt.Printf("Stored credentials for %s\n", host)
+		return nil
+
+	case "remove":
+		if len(args) < 2 {
+			return fmt.Errorf("usage: tin config credentials remove <host>")
+		}
+		host := args[1]
+		if err := credStore.Remove(host); err != nil {
+			return err
+		}
+		fmt.Printf("Removed credentials for %s\n", host)
+		return nil
+
+	case "list":
+		return credentialsList(repo)
+
+	default:
+		return fmt.Errorf("unknown credentials subcommand: %s\n\nUsage:\n  tin config credentials [list]           List stored credentials\n  tin config credentials add <host> <token>  Add credentials for a host\n  tin config credentials remove <host>       Remove credentials for a host", args[0])
+	}
+}
+
+func credentialsList(repo *storage.Repository) error {
+	config, err := repo.ReadConfig()
+	if err != nil {
+		return err
+	}
+
+	if len(config.Credentials) == 0 {
+		fmt.Println("No stored credentials")
+		if config.AuthToken != "" {
+			fmt.Printf("\nLegacy auth_token: %s***\n", config.AuthToken[:min(6, len(config.AuthToken))])
+		}
+		return nil
+	}
+
+	fmt.Println("Stored credentials:")
+	for _, cred := range config.Credentials {
+		// Mask the token for display
+		maskedToken := cred.Token[:min(6, len(cred.Token))] + "***"
+		fmt.Printf("  %s = %s\n", cred.Host, maskedToken)
+	}
+
+	if config.AuthToken != "" {
+		fmt.Printf("\nLegacy auth_token: %s***\n", config.AuthToken[:min(6, len(config.AuthToken))])
+	}
+
+	return nil
+}
+
 func printConfigHelp() {
 	fmt.Println(`Usage: tin config [command]
 
 View and modify tin configuration.
 
 Commands:
-  (none), list     Show all configuration values
-  get <key>        Get a specific configuration value
+  (none), list      Show all configuration values
+  get <key>         Get a specific configuration value
   set <key> <value> Set a configuration value
+  credentials       Manage per-host credentials (see below)
 
-Available keys:
+Credentials Commands:
+  credentials [list]              List stored credentials
+  credentials add <host> <token>  Store credentials for a host
+  credentials remove <host>       Remove credentials for a host
+
+Available config keys:
   thread_host_url  Base URL for tin web viewer (e.g., http://localhost:8080)
   code_host_url    URL for code repository (e.g., https://github.com/user/repo)
+  auth_token       Legacy auth token (deprecated, use credentials instead)
+
+Environment Variables:
+  TIN_AUTH_TOKEN   If set, overrides all stored credentials
 
 Examples:
-  tin config                                    # List all config
-  tin config get thread_host_url                # Get thread host URL
-  tin config set thread_host_url http://localhost:8080`)
+  tin config                                      # List all config
+  tin config get thread_host_url                  # Get thread host URL
+  tin config set thread_host_url http://localhost:8080
+  tin config credentials add tinhub.dev th_xxxxx  # Store credential for host
+  tin config credentials                          # List stored credentials`)
 }

--- a/internal/commands/hooks.go
+++ b/internal/commands/hooks.go
@@ -4,7 +4,12 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"time"
 
+	"github.com/dadlerj/tin/internal/agents"
+	_ "github.com/dadlerj/tin/internal/agents/claudecode" // Register agent
+	"github.com/dadlerj/tin/internal/agents/codex"
+	_ "github.com/dadlerj/tin/internal/agents/cursor" // Register agent
 	"github.com/dadlerj/tin/internal/hooks"
 )
 
@@ -22,6 +27,7 @@ func Hooks(args []string) error {
 		return hooksInstall(subargs)
 	case "uninstall":
 		return hooksUninstall(subargs)
+	// Claude Code hooks (legacy, maintained for backwards compatibility)
 	case "session-start":
 		return hookSessionStart()
 	case "user-prompt":
@@ -30,6 +36,16 @@ func Hooks(args []string) error {
 		return hookStop()
 	case "session-end":
 		return hookSessionEnd()
+	// Cursor hooks
+	case "cursor-prompt":
+		return hookCursorPrompt()
+	case "cursor-stop":
+		return hookCursorStop()
+	case "cursor-file-edit":
+		return hookCursorFileEdit()
+	// Codex notification
+	case "codex-notify":
+		return hookCodexNotify(subargs)
 	case "-h", "--help":
 		printHooksHelp()
 		return nil
@@ -40,6 +56,8 @@ func Hooks(args []string) error {
 
 func hooksInstall(args []string) error {
 	global := false
+	agentNames := []string{}
+
 	for _, arg := range args {
 		switch arg {
 		case "-h", "--help":
@@ -47,7 +65,18 @@ func hooksInstall(args []string) error {
 			return nil
 		case "--global", "-g":
 			global = true
+		case "--claude-code", "--claudecode":
+			agentNames = append(agentNames, "claude-code")
+		case "--cursor":
+			agentNames = append(agentNames, "cursor")
+		case "--all":
+			agentNames = append(agentNames, "claude-code", "cursor")
 		}
+	}
+
+	// Default to claude-code if no agents specified
+	if len(agentNames) == 0 {
+		agentNames = []string{"claude-code"}
 	}
 
 	cwd, err := os.Getwd()
@@ -55,25 +84,40 @@ func hooksInstall(args []string) error {
 		return err
 	}
 
-	if err := hooks.InstallClaudeCodeHooks(cwd, global); err != nil {
-		return err
-	}
-
-	if err := hooks.InstallSlashCommands(cwd, global); err != nil {
-		return err
-	}
-
 	location := "project"
 	if global {
 		location = "global"
 	}
-	fmt.Printf("Installed tin hooks for Claude Code (%s)\n", location)
+
+	for _, name := range agentNames {
+		switch name {
+		case "claude-code":
+			if err := hooks.InstallClaudeCodeHooks(cwd, global); err != nil {
+				return err
+			}
+			if err := hooks.InstallSlashCommands(cwd, global); err != nil {
+				return err
+			}
+			fmt.Printf("Installed tin hooks for Claude Code (%s)\n", location)
+
+		case "cursor":
+			if cursorHandler, ok := agents.GetHook("cursor"); ok {
+				if err := cursorHandler.Install(cwd, global); err != nil {
+					return err
+				}
+				fmt.Printf("Installed tin hooks for Cursor (%s)\n", location)
+			} else {
+				fmt.Fprintf(os.Stderr, "Warning: Cursor agent not registered\n")
+			}
+		}
+	}
+
 	fmt.Println("\nHooks installed:")
 	fmt.Println("  - SessionStart: Creates/resumes thread tracking")
 	fmt.Println("  - UserPromptSubmit: Records human messages")
 	fmt.Println("  - Stop: Records assistant responses and tool calls")
 	fmt.Println("  - SessionEnd: Marks thread as complete")
-	fmt.Println("\nSlash commands installed:")
+	fmt.Println("\nSlash commands installed (Claude Code only):")
 	fmt.Println("  - /branches: List all branches (current marked with *)")
 	fmt.Println("  - /commit [message]: Commit staged threads")
 	fmt.Println("  - /checkout [branch]: Switch to another branch")
@@ -180,39 +224,194 @@ func readHookInput() (*hooks.HookInput, error) {
 	return &input, nil
 }
 
+// Cursor hook handlers
+
+// CursorHookInput represents input from Cursor hooks
+type CursorHookInput struct {
+	ConversationID string `json:"conversation_id"`
+	GenerationID   string `json:"generation_id"`
+	Model          string `json:"model"`
+	HookEventName  string `json:"hook_event_name"`
+	WorkspaceRoots []string `json:"workspace_roots"`
+	UserEmail      *string `json:"user_email"`
+	// For beforeSubmitPrompt
+	Prompt string `json:"prompt,omitempty"`
+	// For stop
+	Text     string `json:"text,omitempty"`
+	Duration int    `json:"duration,omitempty"`
+}
+
+func hookCursorPrompt() error {
+	input, err := readCursorHookInput()
+	if err != nil {
+		return err
+	}
+	if input == nil {
+		return nil
+	}
+
+	// Convert to agents.HookEvent and dispatch
+	handler, ok := agents.GetHook("cursor")
+	if !ok {
+		return nil // Cursor agent not registered
+	}
+
+	cwd := ""
+	if len(input.WorkspaceRoots) > 0 {
+		cwd = input.WorkspaceRoots[0]
+	}
+
+	event := &agents.HookEvent{
+		Type:      agents.HookEventUserPrompt,
+		SessionID: input.ConversationID,
+		Cwd:       cwd,
+		Timestamp: time.Now().UTC(),
+		Prompt:    input.Prompt,
+	}
+
+	_, err = handler.HandleEvent(event)
+	return err
+}
+
+func hookCursorStop() error {
+	input, err := readCursorHookInput()
+	if err != nil {
+		return err
+	}
+	if input == nil {
+		return nil
+	}
+
+	handler, ok := agents.GetHook("cursor")
+	if !ok {
+		return nil
+	}
+
+	cwd := ""
+	if len(input.WorkspaceRoots) > 0 {
+		cwd = input.WorkspaceRoots[0]
+	}
+
+	event := &agents.HookEvent{
+		Type:      agents.HookEventAssistantStop,
+		SessionID: input.ConversationID,
+		Cwd:       cwd,
+		Timestamp: time.Now().UTC(),
+		Response:  input.Text,
+	}
+
+	_, err = handler.HandleEvent(event)
+	return err
+}
+
+func hookCursorFileEdit() error {
+	input, err := readCursorHookInput()
+	if err != nil {
+		return err
+	}
+	if input == nil {
+		return nil
+	}
+
+	handler, ok := agents.GetHook("cursor")
+	if !ok {
+		return nil
+	}
+
+	cwd := ""
+	if len(input.WorkspaceRoots) > 0 {
+		cwd = input.WorkspaceRoots[0]
+	}
+
+	event := &agents.HookEvent{
+		Type:      agents.HookEventFileEdit,
+		SessionID: input.ConversationID,
+		Cwd:       cwd,
+		Timestamp: time.Now().UTC(),
+	}
+
+	_, err = handler.HandleEvent(event)
+	return err
+}
+
+func readCursorHookInput() (*CursorHookInput, error) {
+	var input CursorHookInput
+	decoder := json.NewDecoder(os.Stdin)
+	if err := decoder.Decode(&input); err != nil {
+		cwd, _ := os.Getwd()
+		if cwd != "" {
+			if _, statErr := os.Stat(cwd + "/.tin"); os.IsNotExist(statErr) {
+				return nil, nil
+			}
+		}
+		return nil, fmt.Errorf("failed to read Cursor hook input: %w", err)
+	}
+	return &input, nil
+}
+
+// Codex notification handler
+
+func hookCodexNotify(args []string) error {
+	// Codex passes JSON as first argument, not stdin
+	event, err := codex.ParseNotifyArgs(args)
+	if err != nil {
+		return err
+	}
+
+	handler, ok := agents.GetNotify("codex")
+	if !ok {
+		return nil // Codex agent not registered
+	}
+
+	return handler.HandleNotification(event)
+}
+
 func printHooksHelp() {
 	fmt.Println(`Manage tin hooks for AI coding agents
 
 Usage: tin hooks <command>
 
 Commands:
-  install     Install hooks for Claude Code
-  uninstall   Remove hooks from Claude Code
+  install     Install hooks for AI agents
+  uninstall   Remove hooks from AI agents
+
+Supported agents:
+  --claude-code   Claude Code (default)
+  --cursor        Cursor IDE
+  --all           All hook-based agents
 
 The hooks integration automatically tracks your conversations with
 AI coding agents, creating threads that can be staged and committed.
 
 Examples:
-  tin hooks install         Install hooks for current project
-  tin hooks install -g      Install hooks globally
-  tin hooks uninstall       Remove hooks from current project`)
+  tin hooks install               Install Claude Code hooks (project)
+  tin hooks install -g            Install Claude Code hooks (global)
+  tin hooks install --cursor      Install Cursor hooks
+  tin hooks install --all         Install all available hooks
+  tin hooks uninstall             Remove hooks from current project`)
 }
 
 func printHooksInstallHelp() {
-	fmt.Println(`Install tin hooks for Claude Code
+	fmt.Println(`Install tin hooks for AI coding agents
 
-Usage: tin hooks install [options]
+Usage: tin hooks install [options] [--agent]
 
 Options:
-  -g, --global  Install to global Claude Code settings (~/.claude/settings.json)
-                instead of project settings (.claude/settings.json)
+  -g, --global    Install globally instead of project-level
 
-This command adds hooks to Claude Code that will automatically:
+Agents:
+  --claude-code   Claude Code (default if no agent specified)
+  --cursor        Cursor IDE
+  --all           All hook-based agents
+
+This command adds hooks that will automatically:
   - Track conversation sessions as threads
   - Record human prompts and assistant responses
   - Capture tool calls and git state changes
   - Auto-stage threads for easy committing
 
 After installation, your conversations will be tracked automatically.
-Use 'tin status' to see active threads and 'tin commit' to save your work.`)
+Use 'tin status' to see active threads and 'tin commit' to save your work.
+
+For Codex CLI (notification-based), run 'tin codex setup' for instructions.`)
 }

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -65,9 +65,9 @@ func Pull(args []string) error {
 			return err
 		}
 
-		// Get credentials from store
+		// Get credentials from store (use Address() for host:port format)
 		credStore := remote.NewCredentialStore()
-		creds, _ := credStore.Get(parsedURL.Host)
+		creds, _ := credStore.Get(parsedURL.Address())
 
 		// Connect to remote with credentials
 		client, err := remote.Dial(remoteConfig.URL, creds)

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -59,8 +59,18 @@ func Pull(args []string) error {
 	if err == nil {
 		fmt.Printf("Pulling tin from %s (%s)...\n", remoteName, remoteConfig.URL)
 
-		// Connect to remote
-		client, err := remote.Dial(remoteConfig.URL)
+		// Parse URL to get host for credential lookup
+		parsedURL, err := remote.ParseURL(remoteConfig.URL)
+		if err != nil {
+			return err
+		}
+
+		// Get credentials from store
+		credStore := remote.NewCredentialStore(repo.RootPath)
+		creds, _ := credStore.Get(parsedURL.Host)
+
+		// Connect to remote with credentials
+		client, err := remote.Dial(remoteConfig.URL, creds)
 		if err != nil {
 			return err
 		}

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -5,7 +5,6 @@ import (
 	"os"
 	"strings"
 
-	"github.com/dadlerj/tin/internal/remote"
 	"github.com/dadlerj/tin/internal/storage"
 )
 
@@ -59,18 +58,8 @@ func Pull(args []string) error {
 	if err == nil {
 		fmt.Printf("Pulling tin from %s (%s)...\n", remoteName, remoteConfig.URL)
 
-		// Parse URL to get host for credential lookup
-		parsedURL, err := remote.ParseURL(remoteConfig.URL)
-		if err != nil {
-			return err
-		}
-
-		// Get credentials from store (use Address() for host:port format)
-		credStore := remote.NewCredentialStore()
-		creds, _ := credStore.Get(parsedURL.Address())
-
-		// Connect to remote with credentials
-		client, err := remote.Dial(remoteConfig.URL, creds)
+		// Connect to remote with auth (prompts for credentials if needed)
+		client, err := dialWithCredentials(remoteConfig.URL, repo)
 		if err != nil {
 			return err
 		}

--- a/internal/commands/pull.go
+++ b/internal/commands/pull.go
@@ -66,7 +66,7 @@ func Pull(args []string) error {
 		}
 
 		// Get credentials from store
-		credStore := remote.NewCredentialStore(repo.RootPath)
+		credStore := remote.NewCredentialStore()
 		creds, _ := credStore.Get(parsedURL.Host)
 
 		// Connect to remote with credentials

--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -107,7 +107,7 @@ func dialWithCredentials(remoteURL string, repo *storage.Repository) (*remote.Cl
 	}
 
 	// Get credentials from store
-	credStore := remote.NewCredentialStore(repo.RootPath)
+	credStore := remote.NewCredentialStore()
 	creds, _ := credStore.Get(parsedURL.Host)
 
 	return remote.Dial(remoteURL, creds)

--- a/internal/commands/push.go
+++ b/internal/commands/push.go
@@ -106,9 +106,9 @@ func dialWithCredentials(remoteURL string, repo *storage.Repository) (*remote.Cl
 		return nil, err
 	}
 
-	// Get credentials from store
+	// Get credentials from store (use Address() for host:port format)
 	credStore := remote.NewCredentialStore()
-	creds, _ := credStore.Get(parsedURL.Host)
+	creds, _ := credStore.Get(parsedURL.Address())
 
 	return remote.Dial(remoteURL, creds)
 }

--- a/internal/remote/credentials.go
+++ b/internal/remote/credentials.go
@@ -1,0 +1,153 @@
+package remote
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+)
+
+// CredentialEntry represents stored credentials for a host
+type CredentialEntry struct {
+	Host  string `json:"host"`
+	Token string `json:"token"`
+}
+
+// CredentialStore manages credentials for remote operations
+type CredentialStore struct {
+	repoPath string
+}
+
+// NewCredentialStore creates a new credential store for the given repository
+func NewCredentialStore(repoPath string) *CredentialStore {
+	return &CredentialStore{
+		repoPath: repoPath,
+	}
+}
+
+// Get retrieves credentials for the given host.
+// It checks in order:
+// 1. TIN_AUTH_TOKEN environment variable
+// 2. Per-host credentials in .tin/config
+// 3. Legacy auth_token in .tin/config (for backward compatibility)
+func (s *CredentialStore) Get(host string) (*Credentials, error) {
+	// 1. Check environment variable (highest priority)
+	if token := os.Getenv("TIN_AUTH_TOKEN"); token != "" {
+		return &Credentials{
+			Username: "x-token-auth",
+			Password: token,
+		}, nil
+	}
+
+	// 2. Check per-host credentials in config
+	config, err := s.readConfig()
+	if err != nil {
+		return nil, nil // No config file, no credentials
+	}
+
+	// Look for matching host
+	for _, entry := range config.Credentials {
+		if entry.Host == host {
+			return &Credentials{
+				Username: "x-token-auth",
+				Password: entry.Token,
+			}, nil
+		}
+	}
+
+	// 3. Fall back to legacy auth_token (backward compatibility)
+	if config.AuthToken != "" {
+		return &Credentials{
+			Username: "x-token-auth",
+			Password: config.AuthToken,
+		}, nil
+	}
+
+	return nil, nil // No credentials found
+}
+
+// Store saves credentials for the given host
+func (s *CredentialStore) Store(host, token string) error {
+	config, err := s.readConfig()
+	if err != nil {
+		// Create new config if it doesn't exist
+		config = &configFile{
+			Version:     1,
+			Credentials: []CredentialEntry{},
+		}
+	}
+
+	// Update or add entry
+	found := false
+	for i, entry := range config.Credentials {
+		if entry.Host == host {
+			config.Credentials[i].Token = token
+			found = true
+			break
+		}
+	}
+	if !found {
+		config.Credentials = append(config.Credentials, CredentialEntry{
+			Host:  host,
+			Token: token,
+		})
+	}
+
+	return s.writeConfig(config)
+}
+
+// Remove removes credentials for the given host
+func (s *CredentialStore) Remove(host string) error {
+	config, err := s.readConfig()
+	if err != nil {
+		return nil // No config, nothing to remove
+	}
+
+	// Find and remove entry
+	newCreds := make([]CredentialEntry, 0, len(config.Credentials))
+	for _, entry := range config.Credentials {
+		if entry.Host != host {
+			newCreds = append(newCreds, entry)
+		}
+	}
+	config.Credentials = newCreds
+
+	return s.writeConfig(config)
+}
+
+// configFile represents the .tin/config file structure
+// This is a local copy to avoid circular imports with storage package
+type configFile struct {
+	Version       int               `json:"version"`
+	Remotes       []json.RawMessage `json:"remotes,omitempty"`
+	CodeHostURL   string            `json:"code_host_url,omitempty"`
+	ThreadHostURL string            `json:"thread_host_url,omitempty"`
+	AuthToken     string            `json:"auth_token,omitempty"`
+	Credentials   []CredentialEntry `json:"credentials,omitempty"`
+}
+
+func (s *CredentialStore) configPath() string {
+	return filepath.Join(s.repoPath, ".tin", "config")
+}
+
+func (s *CredentialStore) readConfig() (*configFile, error) {
+	data, err := os.ReadFile(s.configPath())
+	if err != nil {
+		return nil, err
+	}
+
+	var config configFile
+	if err := json.Unmarshal(data, &config); err != nil {
+		return nil, err
+	}
+
+	return &config, nil
+}
+
+func (s *CredentialStore) writeConfig(config *configFile) error {
+	data, err := json.MarshalIndent(config, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	return os.WriteFile(s.configPath(), data, 0600)
+}

--- a/internal/remote/http_server.go
+++ b/internal/remote/http_server.go
@@ -28,6 +28,33 @@ func (v *AllowAllAuthValidator) Validate(username, password string) (string, boo
 	return username, true
 }
 
+// TokenAuthValidator validates against a preset list of username/password pairs
+type TokenAuthValidator struct {
+	// credentials maps username to password
+	credentials map[string]string
+}
+
+// NewTokenAuthValidator creates a validator with the given username/password pairs
+func NewTokenAuthValidator(creds map[string]string) *TokenAuthValidator {
+	return &TokenAuthValidator{
+		credentials: creds,
+	}
+}
+
+func (v *TokenAuthValidator) Validate(username, password string) (string, bool) {
+	if v.credentials == nil {
+		return "", false
+	}
+	expectedPassword, exists := v.credentials[username]
+	if !exists {
+		return "", false
+	}
+	if expectedPassword != password {
+		return "", false
+	}
+	return username, true
+}
+
 // HTTPHandler handles HTTP requests for the TIN protocol
 type HTTPHandler struct {
 	rootPath      string

--- a/internal/remote/http_server.go
+++ b/internal/remote/http_server.go
@@ -1,0 +1,421 @@
+package remote
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/base64"
+	"fmt"
+	"io"
+	"log"
+	"net/http"
+	"path/filepath"
+	"strings"
+
+	"github.com/dadlerj/tin/internal/model"
+	"github.com/dadlerj/tin/internal/storage"
+)
+
+// AuthValidator validates authentication credentials
+type AuthValidator interface {
+	// Validate checks if the credentials are valid and returns the user identifier
+	Validate(username, password string) (userID string, valid bool)
+}
+
+// AllowAllAuthValidator allows any credentials (for testing/development)
+type AllowAllAuthValidator struct{}
+
+func (v *AllowAllAuthValidator) Validate(username, password string) (string, bool) {
+	return username, true
+}
+
+// HTTPHandler handles HTTP requests for the TIN protocol
+type HTTPHandler struct {
+	rootPath      string
+	autoCreate    bool
+	authValidator AuthValidator
+}
+
+// NewHTTPHandler creates a new HTTP handler
+func NewHTTPHandler(rootPath string, autoCreate bool, authValidator AuthValidator) *HTTPHandler {
+	if authValidator == nil {
+		authValidator = &AllowAllAuthValidator{}
+	}
+	return &HTTPHandler{
+		rootPath:      rootPath,
+		autoCreate:    autoCreate,
+		authValidator: authValidator,
+	}
+}
+
+// ServeHTTP implements http.Handler
+func (h *HTTPHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Extract Basic Auth credentials
+	username, password, hasAuth := r.BasicAuth()
+	if !hasAuth {
+		w.Header().Set("WWW-Authenticate", `Basic realm="tin"`)
+		http.Error(w, "Authentication required", http.StatusUnauthorized)
+		return
+	}
+
+	userID, valid := h.authValidator.Validate(username, password)
+	if !valid {
+		http.Error(w, "Invalid credentials", http.StatusUnauthorized)
+		return
+	}
+
+	// Parse path to get repo path and operation
+	// Expected format: /{repo-path}/tin-{operation}
+	// e.g., /user/repo/tin-receive-pack
+	path := strings.TrimPrefix(r.URL.Path, "/")
+
+	var repoPath, operation string
+	if idx := strings.LastIndex(path, "/tin-"); idx != -1 {
+		repoPath = "/" + path[:idx]
+		opPart := path[idx+5:] // skip "/tin-"
+		switch opPart {
+		case "receive-pack":
+			operation = "push"
+		case "upload-pack":
+			operation = "pull"
+		case "config":
+			operation = "config"
+		default:
+			http.Error(w, "Unknown operation", http.StatusBadRequest)
+			return
+		}
+	} else {
+		http.Error(w, "Invalid path format", http.StatusBadRequest)
+		return
+	}
+
+	log.Printf("[HTTP %s] repo: %s, operation: %s", userID, repoPath, operation)
+
+	// Resolve repository path
+	fullRepoPath, err := h.resolveRepoPath(repoPath)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusBadRequest)
+		return
+	}
+
+	// Open or create repository
+	repo, err := storage.OpenBare(fullRepoPath)
+	if err != nil {
+		if h.autoCreate && operation == "push" {
+			log.Printf("[HTTP %s] creating new repository: %s", userID, fullRepoPath)
+			repo, err = storage.InitBare(fullRepoPath)
+			if err != nil {
+				http.Error(w, "Failed to create repository", http.StatusInternalServerError)
+				return
+			}
+		} else {
+			http.Error(w, "Repository not found", http.StatusNotFound)
+			return
+		}
+	}
+
+	// Set response content type
+	w.Header().Set("Content-Type", ContentTypeTinProtocol)
+
+	// Create a buffer for the response
+	var respBuf bytes.Buffer
+
+	// Create protocol connection adapters using the helper
+	reqPC := NewProtocolConnFromHTTP(r.Body, io.Discard)
+	respPC := NewProtocolConnFromHTTP(strings.NewReader(""), &respBuf)
+
+	// Handle the operation
+	switch operation {
+	case "push":
+		h.handlePush(reqPC, respPC, repo, userID)
+	case "pull":
+		h.handlePull(reqPC, respPC, repo, userID)
+	case "config":
+		h.handleConfig(reqPC, respPC, repo, userID)
+	}
+
+	// Write response
+	w.Write(respBuf.Bytes())
+}
+
+// resolveRepoPath resolves the repository path (same logic as TCP server)
+func (h *HTTPHandler) resolveRepoPath(clientPath string) (string, error) {
+	// Clean the path
+	cleanPath := strings.TrimLeft(clientPath, "/")
+	cleanPath = filepath.Clean(cleanPath)
+
+	// Reject paths that try to escape
+	if cleanPath == ".." || strings.HasPrefix(cleanPath, "../") || strings.Contains(cleanPath, "/../") {
+		return "", fmt.Errorf("invalid repository path: %s", clientPath)
+	}
+
+	if cleanPath == "" || cleanPath == "." {
+		return "", fmt.Errorf("repository path required")
+	}
+
+	// Join with root path
+	fullPath := filepath.Join(h.rootPath, cleanPath)
+
+	// Double-check the result is under root
+	absRoot, _ := filepath.Abs(h.rootPath)
+	absPath, _ := filepath.Abs(fullPath)
+	if !strings.HasPrefix(absPath, absRoot+string(filepath.Separator)) && absPath != absRoot {
+		return "", fmt.Errorf("invalid repository path: %s", clientPath)
+	}
+
+	return fullPath, nil
+}
+
+func (h *HTTPHandler) handlePush(reqPC, respPC *ProtocolConn, repo *storage.Repository, userID string) {
+	// Send refs advertisement
+	refs, err := buildRefsMessage(repo)
+	if err != nil {
+		respPC.SendError(ErrCodeInternal, "failed to build refs: "+err.Error())
+		return
+	}
+
+	if err := respPC.Send(MsgRefs, refs); err != nil {
+		log.Printf("[HTTP %s] failed to send refs: %v", userID, err)
+		return
+	}
+
+	// Receive pack from request
+	msg, err := reqPC.Receive()
+	if err != nil {
+		log.Printf("[HTTP %s] failed to receive pack: %v", userID, err)
+		respPC.SendError(ErrCodeInvalidRequest, "failed to receive pack")
+		return
+	}
+
+	if msg.Type != MsgPack {
+		respPC.SendError(ErrCodeInvalidRequest, "expected pack message")
+		return
+	}
+
+	var pack PackMessage
+	if err := msg.DecodePayload(&pack); err != nil {
+		respPC.SendError(ErrCodeInvalidRequest, "invalid pack payload")
+		return
+	}
+
+	// Save received objects
+	for _, thread := range pack.Threads {
+		t := thread
+		if err := repo.SaveThread(&t); err != nil {
+			log.Printf("[HTTP %s] failed to save thread %s: %v", userID, thread.ID, err)
+		}
+	}
+
+	for _, commit := range pack.Commits {
+		c := commit
+		if err := repo.SaveCommit(&c); err != nil {
+			log.Printf("[HTTP %s] failed to save commit %s: %v", userID, commit.ID, err)
+		}
+	}
+
+	log.Printf("[HTTP %s] received %d threads, %d commits", userID, len(pack.Threads), len(pack.Commits))
+
+	// Receive ref updates
+	msg, err = reqPC.Receive()
+	if err != nil {
+		log.Printf("[HTTP %s] failed to receive update-refs: %v", userID, err)
+		respPC.SendError(ErrCodeInvalidRequest, "failed to receive update-refs")
+		return
+	}
+
+	if msg.Type != MsgUpdateRefs {
+		respPC.SendError(ErrCodeInvalidRequest, "expected update-refs message")
+		return
+	}
+
+	var updateRefs UpdateRefsMessage
+	if err := msg.DecodePayload(&updateRefs); err != nil {
+		respPC.SendError(ErrCodeInvalidRequest, "invalid update-refs payload")
+		return
+	}
+
+	// Apply ref updates
+	for branch, commitID := range updateRefs.Updates {
+		if !updateRefs.Force {
+			currentCommitID, _ := repo.ReadBranch(branch)
+			if currentCommitID != "" {
+				if !isAncestor(repo, currentCommitID, commitID) {
+					respPC.SendError(ErrCodeNotFastForward, fmt.Sprintf("non-fast-forward update rejected for %s", branch))
+					return
+				}
+			}
+		}
+
+		if err := repo.WriteBranch(branch, commitID); err != nil {
+			respPC.SendError(ErrCodeInternal, "failed to update ref: "+err.Error())
+			return
+		}
+		log.Printf("[HTTP %s] updated %s -> %s", userID, branch, commitID[:12])
+	}
+
+	respPC.SendOK("push successful")
+}
+
+func (h *HTTPHandler) handlePull(reqPC, respPC *ProtocolConn, repo *storage.Repository, userID string) {
+	// Send refs advertisement
+	refs, err := buildRefsMessage(repo)
+	if err != nil {
+		respPC.SendError(ErrCodeInternal, "failed to build refs: "+err.Error())
+		return
+	}
+
+	if err := respPC.Send(MsgRefs, refs); err != nil {
+		log.Printf("[HTTP %s] failed to send refs: %v", userID, err)
+		return
+	}
+
+	// Receive want message
+	msg, err := reqPC.Receive()
+	if err != nil {
+		log.Printf("[HTTP %s] failed to receive want: %v", userID, err)
+		respPC.SendError(ErrCodeInvalidRequest, "failed to receive want")
+		return
+	}
+
+	if msg.Type != MsgWant {
+		respPC.SendError(ErrCodeInvalidRequest, "expected want message")
+		return
+	}
+
+	var want WantMessage
+	if err := msg.DecodePayload(&want); err != nil {
+		respPC.SendError(ErrCodeInvalidRequest, "invalid want payload")
+		return
+	}
+
+	// Build pack with requested objects
+	pack := PackMessage{
+		Commits: make([]model.TinCommit, 0),
+		Threads: make([]model.Thread, 0),
+	}
+
+	for _, threadID := range want.ThreadIDs {
+		thread, err := repo.LoadThread(threadID)
+		if err != nil {
+			continue
+		}
+		pack.Threads = append(pack.Threads, *thread)
+	}
+
+	for _, versionRef := range want.ThreadVersions {
+		thread, err := repo.LoadThreadVersion(versionRef.ThreadID, versionRef.ContentHash)
+		if err != nil {
+			continue
+		}
+		pack.Threads = append(pack.Threads, *thread)
+	}
+
+	for _, commitID := range want.CommitIDs {
+		commit, err := repo.LoadCommit(commitID)
+		if err != nil {
+			continue
+		}
+		pack.Commits = append(pack.Commits, *commit)
+	}
+
+	if err := respPC.Send(MsgPack, pack); err != nil {
+		log.Printf("[HTTP %s] failed to send pack: %v", userID, err)
+		return
+	}
+
+	log.Printf("[HTTP %s] sent %d threads, %d commits", userID, len(pack.Threads), len(pack.Commits))
+}
+
+func (h *HTTPHandler) handleConfig(reqPC, respPC *ProtocolConn, repo *storage.Repository, userID string) {
+	msg, err := reqPC.Receive()
+	if err != nil {
+		log.Printf("[HTTP %s] failed to receive config message: %v", userID, err)
+		respPC.SendError(ErrCodeInvalidRequest, "failed to receive config message")
+		return
+	}
+
+	switch msg.Type {
+	case MsgGetConfig:
+		config, err := repo.ReadConfig()
+		if err != nil {
+			respPC.SendError(ErrCodeInternal, "failed to read config")
+			return
+		}
+		configMsg := ConfigMessage{
+			CodeHostURL: config.CodeHostURL,
+		}
+		respPC.Send(MsgConfig, configMsg)
+		log.Printf("[HTTP %s] sent config", userID)
+
+	case MsgSetConfig:
+		var setConfig SetConfigMessage
+		if err := msg.DecodePayload(&setConfig); err != nil {
+			respPC.SendError(ErrCodeInvalidRequest, "invalid set-config payload")
+			return
+		}
+
+		config, err := repo.ReadConfig()
+		if err != nil {
+			respPC.SendError(ErrCodeInternal, "failed to read config")
+			return
+		}
+
+		config.CodeHostURL = setConfig.CodeHostURL
+		if err := repo.WriteConfig(config); err != nil {
+			respPC.SendError(ErrCodeInternal, "failed to write config")
+			return
+		}
+
+		respPC.SendOK("config updated")
+		log.Printf("[HTTP %s] updated code_host_url to %s", userID, setConfig.CodeHostURL)
+
+	default:
+		respPC.SendError(ErrCodeInvalidRequest, "expected get-config or set-config message")
+	}
+}
+
+// ParseBasicAuth parses a Basic auth header value
+func ParseBasicAuth(auth string) (username, password string, ok bool) {
+	const prefix = "Basic "
+	if !strings.HasPrefix(auth, prefix) {
+		return "", "", false
+	}
+
+	decoded, err := base64.StdEncoding.DecodeString(auth[len(prefix):])
+	if err != nil {
+		return "", "", false
+	}
+
+	parts := strings.SplitN(string(decoded), ":", 2)
+	if len(parts) != 2 {
+		return "", "", false
+	}
+
+	return parts[0], parts[1], true
+}
+
+// httpReadWriter wraps separate readers and writers
+type httpReadWriter struct {
+	r io.Reader
+	w io.Writer
+}
+
+func (rw *httpReadWriter) Read(p []byte) (n int, err error) {
+	return rw.r.Read(p)
+}
+
+func (rw *httpReadWriter) Write(p []byte) (n int, err error) {
+	return rw.w.Write(p)
+}
+
+// NewProtocolConnFromHTTP creates a ProtocolConn from HTTP request/response
+func NewProtocolConnFromHTTP(r io.Reader, w io.Writer) *ProtocolConn {
+	return &ProtocolConn{
+		reader: bufio.NewReader(r),
+		writer: w,
+	}
+}

--- a/internal/remote/https_transport.go
+++ b/internal/remote/https_transport.go
@@ -1,0 +1,231 @@
+package remote
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+)
+
+const (
+	// ContentTypeTinProtocol is the content type for TIN protocol messages
+	ContentTypeTinProtocol = "application/x-tin-protocol"
+)
+
+// HTTPSTransport implements Transport over HTTPS
+type HTTPSTransport struct {
+	client    *http.Client
+	baseURL   string
+	creds     *Credentials
+	operation string // Set from HelloMessage
+
+	// Message buffering for request/response batching
+	sendBuf []Message
+	recvBuf []Message
+}
+
+// NewHTTPSTransport creates a new HTTPS transport
+func NewHTTPSTransport(url *ParsedURL, creds *Credentials) (*HTTPSTransport, error) {
+	// Build base URL
+	port := url.Port
+	if port == "" || port == "443" {
+		// Don't include default port in URL
+		port = ""
+	}
+
+	var baseURL string
+	if port != "" {
+		baseURL = fmt.Sprintf("https://%s:%s%s", url.Host, port, url.Path)
+	} else {
+		baseURL = fmt.Sprintf("https://%s%s", url.Host, url.Path)
+	}
+
+	return &HTTPSTransport{
+		client:  &http.Client{},
+		baseURL: strings.TrimSuffix(baseURL, "/"),
+		creds:   creds,
+		sendBuf: make([]Message, 0),
+		recvBuf: make([]Message, 0),
+	}, nil
+}
+
+// Send buffers a message. The actual HTTP request happens on Receive.
+func (t *HTTPSTransport) Send(msgType MessageType, payload any) error {
+	// Encode payload
+	var payloadBytes json.RawMessage
+	if payload != nil {
+		var err error
+		payloadBytes, err = json.Marshal(payload)
+		if err != nil {
+			return fmt.Errorf("failed to marshal payload: %w", err)
+		}
+	}
+
+	msg := Message{
+		Type:    msgType,
+		Payload: payloadBytes,
+	}
+
+	// Extract operation from hello message
+	if msgType == MsgHello {
+		var hello HelloMessage
+		if err := json.Unmarshal(payloadBytes, &hello); err == nil {
+			t.operation = hello.Operation
+		}
+	}
+
+	t.sendBuf = append(t.sendBuf, msg)
+	return nil
+}
+
+// Receive returns the next message from the response buffer.
+// If the buffer is empty, it flushes pending sends via HTTP and fills the buffer.
+func (t *HTTPSTransport) Receive() (*Message, error) {
+	// If we have buffered responses, return the next one
+	if len(t.recvBuf) > 0 {
+		msg := t.recvBuf[0]
+		t.recvBuf = t.recvBuf[1:]
+		return &msg, nil
+	}
+
+	// No buffered responses - flush pending sends and get response
+	if len(t.sendBuf) == 0 {
+		return nil, fmt.Errorf("no pending messages to send")
+	}
+
+	// Make HTTP request
+	responses, err := t.doRequest()
+	if err != nil {
+		return nil, err
+	}
+
+	// Buffer all responses
+	t.recvBuf = responses
+
+	// Return first response
+	if len(t.recvBuf) == 0 {
+		return nil, fmt.Errorf("server returned no messages")
+	}
+
+	msg := t.recvBuf[0]
+	t.recvBuf = t.recvBuf[1:]
+	return &msg, nil
+}
+
+// doRequest sends buffered messages as an HTTP POST and returns response messages
+func (t *HTTPSTransport) doRequest() ([]Message, error) {
+	// Determine endpoint based on operation
+	endpoint := t.endpointForOperation(t.operation)
+
+	// Encode request messages as newline-delimited JSON
+	var body bytes.Buffer
+	for _, msg := range t.sendBuf {
+		data, err := json.Marshal(msg)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal message: %w", err)
+		}
+		body.Write(data)
+		body.WriteByte('\n')
+	}
+
+	// Clear send buffer
+	t.sendBuf = t.sendBuf[:0]
+
+	// Create HTTP request
+	req, err := http.NewRequest("POST", endpoint, &body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create request: %w", err)
+	}
+
+	req.Header.Set("Content-Type", ContentTypeTinProtocol)
+	req.Header.Set("Accept", ContentTypeTinProtocol)
+
+	// Add Basic Auth if credentials available
+	if t.creds != nil && t.creds.Password != "" {
+		username := t.creds.Username
+		if username == "" {
+			username = "x-token-auth"
+		}
+		auth := base64.StdEncoding.EncodeToString(
+			[]byte(username + ":" + t.creds.Password),
+		)
+		req.Header.Set("Authorization", "Basic "+auth)
+	}
+
+	// Send request
+	resp, err := t.client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("HTTP request failed: %w", err)
+	}
+	defer resp.Body.Close()
+
+	// Check for HTTP-level errors
+	if resp.StatusCode == 401 {
+		return nil, fmt.Errorf("authentication required: server returned 401 Unauthorized")
+	}
+	if resp.StatusCode >= 400 {
+		respBody, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("HTTP error %d: %s", resp.StatusCode, string(respBody))
+	}
+
+	// Parse response messages (newline-delimited JSON)
+	return t.parseResponse(resp.Body)
+}
+
+// endpointForOperation returns the HTTP endpoint for the given operation
+func (t *HTTPSTransport) endpointForOperation(operation string) string {
+	switch operation {
+	case "push":
+		return t.baseURL + "/tin-receive-pack"
+	case "pull":
+		return t.baseURL + "/tin-upload-pack"
+	case "config":
+		return t.baseURL + "/tin-config"
+	default:
+		return t.baseURL + "/tin-" + operation
+	}
+}
+
+// parseResponse parses newline-delimited JSON messages from the response body
+func (t *HTTPSTransport) parseResponse(r io.Reader) ([]Message, error) {
+	var messages []Message
+	scanner := bufio.NewScanner(r)
+
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(line) == 0 {
+			continue
+		}
+
+		var msg Message
+		if err := json.Unmarshal(line, &msg); err != nil {
+			return nil, fmt.Errorf("failed to decode response message: %w", err)
+		}
+		messages = append(messages, msg)
+	}
+
+	if err := scanner.Err(); err != nil {
+		return nil, fmt.Errorf("failed to read response: %w", err)
+	}
+
+	return messages, nil
+}
+
+// Close is a no-op for HTTP (stateless)
+func (t *HTTPSTransport) Close() error {
+	return nil
+}
+
+// SendError sends an error message
+func (t *HTTPSTransport) SendError(code, message string) error {
+	return t.Send(MsgError, ErrorMessage{Code: code, Message: message})
+}
+
+// SendOK sends an OK message
+func (t *HTTPSTransport) SendOK(message string) error {
+	return t.Send(MsgOK, OKMessage{Message: message})
+}

--- a/internal/remote/https_transport.go
+++ b/internal/remote/https_transport.go
@@ -32,17 +32,26 @@ type HTTPSTransport struct {
 // NewHTTPSTransport creates a new HTTPS transport
 func NewHTTPSTransport(url *ParsedURL, creds *Credentials) (*HTTPSTransport, error) {
 	// Build base URL
+	scheme := url.Scheme
+	if scheme == "" {
+		scheme = "https"
+	}
+
 	port := url.Port
-	if port == "" || port == "443" {
+	defaultPort := "443"
+	if scheme == "http" {
+		defaultPort = "80"
+	}
+	if port == "" || port == defaultPort {
 		// Don't include default port in URL
 		port = ""
 	}
 
 	var baseURL string
 	if port != "" {
-		baseURL = fmt.Sprintf("https://%s:%s%s", url.Host, port, url.Path)
+		baseURL = fmt.Sprintf("%s://%s:%s%s", scheme, url.Host, port, url.Path)
 	} else {
-		baseURL = fmt.Sprintf("https://%s%s", url.Host, url.Path)
+		baseURL = fmt.Sprintf("%s://%s%s", scheme, url.Host, url.Path)
 	}
 
 	return &HTTPSTransport{

--- a/internal/remote/https_transport.go
+++ b/internal/remote/https_transport.go
@@ -206,6 +206,10 @@ func (t *HTTPSTransport) endpointForOperation(operation string) string {
 func (t *HTTPSTransport) parseResponse(r io.Reader) ([]Message, error) {
 	var messages []Message
 	scanner := bufio.NewScanner(r)
+	// Increase buffer size to handle large messages (e.g., packs with many commits/threads)
+	// Default is 64KB, increase to 16MB
+	const maxScannerBuffer = 16 * 1024 * 1024
+	scanner.Buffer(make([]byte, 0, 64*1024), maxScannerBuffer)
 
 	for scanner.Scan() {
 		line := scanner.Bytes()

--- a/internal/remote/protocol.go
+++ b/internal/remote/protocol.go
@@ -34,11 +34,18 @@ type Message struct {
 	Payload json.RawMessage `json:"payload,omitempty"`
 }
 
+// AuthInfo contains authentication credentials
+type AuthInfo struct {
+	Type  string `json:"type"`  // "token"
+	Token string `json:"token"` // the auth token (e.g., "th_xxx")
+}
+
 // HelloMessage initiates the connection
 type HelloMessage struct {
-	Version   int    `json:"version"`
-	Operation string `json:"operation"` // "push" or "pull"
-	RepoPath  string `json:"repo_path"` // path to repository on server
+	Version   int       `json:"version"`
+	Operation string    `json:"operation"` // "push" or "pull"
+	RepoPath  string    `json:"repo_path"` // path to repository on server
+	Auth      *AuthInfo `json:"auth,omitempty"`
 }
 
 // RefsMessage advertises refs and object IDs

--- a/internal/remote/tcp_transport.go
+++ b/internal/remote/tcp_transport.go
@@ -1,0 +1,50 @@
+package remote
+
+import (
+	"fmt"
+	"net"
+)
+
+// TCPTransport implements Transport over a raw TCP connection
+type TCPTransport struct {
+	conn net.Conn
+	pc   *ProtocolConn
+}
+
+// NewTCPTransport creates a new TCP transport connected to the given URL
+func NewTCPTransport(url *ParsedURL) (*TCPTransport, error) {
+	conn, err := net.Dial("tcp", url.Address())
+	if err != nil {
+		return nil, fmt.Errorf("failed to connect to %s: %w", url.Address(), err)
+	}
+
+	return &TCPTransport{
+		conn: conn,
+		pc:   NewProtocolConn(conn),
+	}, nil
+}
+
+// Send sends a message with the given type and payload
+func (t *TCPTransport) Send(msgType MessageType, payload any) error {
+	return t.pc.Send(msgType, payload)
+}
+
+// Receive reads and returns the next message
+func (t *TCPTransport) Receive() (*Message, error) {
+	return t.pc.Receive()
+}
+
+// Close closes the TCP connection
+func (t *TCPTransport) Close() error {
+	return t.conn.Close()
+}
+
+// SendError sends an error message
+func (t *TCPTransport) SendError(code, message string) error {
+	return t.pc.SendError(code, message)
+}
+
+// SendOK sends an OK message
+func (t *TCPTransport) SendOK(message string) error {
+	return t.pc.SendOK(message)
+}

--- a/internal/remote/transport.go
+++ b/internal/remote/transport.go
@@ -1,0 +1,20 @@
+package remote
+
+// Transport provides a communication channel for the TIN protocol.
+// Different implementations handle TCP, HTTPS, etc.
+type Transport interface {
+	// Send sends a message with the given type and payload
+	Send(msgType MessageType, payload any) error
+
+	// Receive reads and returns the next message
+	Receive() (*Message, error)
+
+	// Close closes the transport
+	Close() error
+}
+
+// Credentials holds authentication information for a remote
+type Credentials struct {
+	Username string // Can be anything for token auth, often "x-token-auth"
+	Password string // The actual token (th_xxx)
+}

--- a/internal/storage/commits.go
+++ b/internal/storage/commits.go
@@ -108,6 +108,10 @@ func (r *Repository) ReadBranch(name string) (string, error) {
 // WriteBranch writes a branch reference
 func (r *Repository) WriteBranch(name string, commitID string) error {
 	path := filepath.Join(r.TinPath, RefsDir, HeadsDir, name)
+	// Create parent directories if they don't exist (for branches like "feature/foo")
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
 	return os.WriteFile(path, []byte(commitID), 0644)
 }
 

--- a/internal/storage/commits_test.go
+++ b/internal/storage/commits_test.go
@@ -112,21 +112,21 @@ func TestRepository_BranchOperations(t *testing.T) {
 		t.Errorf("expected 0 branches initially, got %d", len(branches))
 	}
 
-	// Create new branch
-	if err := repo.WriteBranch("feature", "commit-123"); err != nil {
+	// Create new branch (with slash to test nested directory creation)
+	if err := repo.WriteBranch("feature/test", "commit-123"); err != nil {
 		t.Fatalf("WriteBranch failed: %v", err)
 	}
 
 	// Verify branch exists
-	if !repo.BranchExists("feature") {
-		t.Error("expected 'feature' branch to exist")
+	if !repo.BranchExists("feature/test") {
+		t.Error("expected 'feature/test' branch to exist")
 	}
 	if repo.BranchExists("nonexistent") {
 		t.Error("expected 'nonexistent' branch to not exist")
 	}
 
 	// Read branch
-	commitID, err := repo.ReadBranch("feature")
+	commitID, err := repo.ReadBranch("feature/test")
 	if err != nil {
 		t.Fatalf("ReadBranch failed: %v", err)
 	}
@@ -152,17 +152,17 @@ func TestRepository_DeleteBranch(t *testing.T) {
 		t.Fatalf("Init failed: %v", err)
 	}
 
-	// Create branch
-	repo.WriteBranch("feature", "commit-123")
+	// Create branch (with slash to test nested directory creation)
+	repo.WriteBranch("feature/test", "commit-123")
 
 	// Delete it
-	if err := repo.DeleteBranch("feature"); err != nil {
+	if err := repo.DeleteBranch("feature/test"); err != nil {
 		t.Fatalf("DeleteBranch failed: %v", err)
 	}
 
 	// Verify deleted
-	if repo.BranchExists("feature") {
-		t.Error("expected 'feature' branch to be deleted")
+	if repo.BranchExists("feature/test") {
+		t.Error("expected 'feature/test' branch to be deleted")
 	}
 }
 

--- a/internal/storage/repository.go
+++ b/internal/storage/repository.go
@@ -36,12 +36,20 @@ type RemoteConfig struct {
 	URL  string `json:"url"`
 }
 
+// CredentialEntry represents stored credentials for a host
+type CredentialEntry struct {
+	Host  string `json:"host"`
+	Token string `json:"token"`
+}
+
 // Config holds tin configuration
 type Config struct {
-	Version       int            `json:"version"`
-	Remotes       []RemoteConfig `json:"remotes,omitempty"`
-	CodeHostURL   string         `json:"code_host_url,omitempty"`
-	ThreadHostURL string         `json:"thread_host_url,omitempty"` // Base URL for tin web viewer (e.g., https://tin.example.com)
+	Version       int               `json:"version"`
+	Remotes       []RemoteConfig    `json:"remotes,omitempty"`
+	CodeHostURL   string            `json:"code_host_url,omitempty"`
+	ThreadHostURL string            `json:"thread_host_url,omitempty"` // Base URL for tin web viewer (e.g., https://tin.example.com)
+	AuthToken     string            `json:"auth_token,omitempty"`      // Deprecated: use Credentials instead
+	Credentials   []CredentialEntry `json:"credentials,omitempty"`     // Per-host authentication tokens
 }
 
 // Index represents the staging area

--- a/skills/tin/REFERENCE.md
+++ b/skills/tin/REFERENCE.md
@@ -1,0 +1,200 @@
+# Tin Reference Documentation
+
+## Full Command Reference
+
+### Status and Info
+
+```bash
+tin status                     # Show staged threads + branch state
+tin branch                     # List branches (* marks current)
+tin log                        # Show commit history with threads
+```
+
+### Committing
+
+```bash
+tin commit -m "message"        # Commit with explicit message
+tin push                       # Push BOTH git and tin to remote
+```
+
+### Branch Operations
+
+```bash
+tin checkout feature-branch    # Switch branches (git + tin)
+tin checkout -b new-feature    # Create and switch to new branch
+tin branch new-feature         # Create branch without switching
+```
+
+### Thread Management
+
+Threads are usually auto-staged by hooks, but can be managed manually:
+
+```bash
+tin add .                      # Stage all unstaged threads
+tin add abc123                 # Stage specific thread
+tin add abc123@10              # Stage first N messages only
+tin add --unstage abc123       # Unstage a thread
+```
+
+### Syncing
+
+```bash
+tin sync --tin-follows-git     # Sync tin HEAD to match git branch
+tin pull                       # Pull threads from remote
+```
+
+### Thread Viewing
+
+```bash
+tin thread list                # List all threads
+tin thread show <id>           # Display thread conversation
+tin thread delete <id>         # Delete a thread (use -f for committed/active)
+```
+
+### Hooks
+
+```bash
+tin hooks install              # Install Claude Code hooks (project)
+tin hooks install --global     # Install hooks globally (~/.claude)
+tin hooks uninstall            # Remove hooks
+```
+
+### Amp Integration
+
+```bash
+tin amp pull                   # Pull latest thread from Amp
+tin amp pull 5                 # Pull 5 most recent threads
+tin amp pull T-019b7d09-...    # Pull specific thread by ID
+```
+
+## Data Model
+
+### Message
+
+Each message in a thread contains:
+- `hash` - Merkle chain hash for integrity
+- `role` - human or assistant
+- `content` - Message text
+- `timestamp` - When the message was created
+- `tool_calls` - Any tool invocations (optional)
+- `git_hash_after` - Git commit hash after this message (optional)
+
+### Thread
+
+A thread is a conversation:
+- `id` - First message hash (unique identifier)
+- `agent` - Which AI agent (claude-code, amp, etc.)
+- `messages[]` - Array of messages
+- `parent` - Parent thread reference for branching (optional)
+
+### TinCommit
+
+A tin commit links threads to git:
+- `id` - Commit hash
+- `message` - Commit message
+- `threads[]` - Array of thread references with message counts
+- `git_commit_hash` - Corresponding git commit
+- `timestamp` - When committed
+- `author` - Who made the commit
+
+## Storage Structure
+
+Tin stores data in `.tin/` directory:
+
+```
+.tin/
+├── config              # Remote configuration
+├── HEAD                # Current branch name
+├── index.json          # Staged threads
+├── threads/            # Thread JSON files
+├── commits/            # Commit JSON files
+└── refs/
+    └── heads/          # Branch references
+```
+
+## Claude Code Hooks
+
+When installed, tin hooks auto-track conversations:
+
+| Hook | Action |
+|------|--------|
+| `SessionStart` | Create new thread |
+| `UserPromptSubmit` | Append human message, auto-stage |
+| `Stop` | Append assistant response + tool calls + git hash |
+| `SessionEnd` | Mark thread complete |
+
+## Advanced Troubleshooting
+
+### Branch Mismatch After Git Checkout
+
+If you accidentally used `git checkout` instead of `tin checkout`:
+
+```bash
+tin sync --tin-follows-git
+```
+
+This syncs tin's HEAD to match git's current branch.
+
+### Recovering from Corrupted State
+
+```bash
+# Check current state
+tin status
+ls -la .tin/
+cat .tin/HEAD
+cat .tin/config
+
+# Reset HEAD if missing
+echo "main" > .tin/HEAD
+tin sync --tin-follows-git
+
+# Re-initialize if needed (preserves config)
+tin init
+```
+
+### Force Commit on Mismatch
+
+If you need to commit despite branch mismatch (not recommended):
+
+```bash
+tin commit --force -m "message"
+```
+
+### Debugging Hook Issues
+
+Check hook output:
+
+```bash
+# Hooks are in .claude/settings.json (local) or ~/.claude/settings.json (global)
+cat .claude/settings.json
+
+# Test hook manually
+tin hook session-start
+tin hook user-prompt
+tin hook stop
+tin hook session-end
+```
+
+### Resetting Remote Configuration
+
+```bash
+# Check current remote
+cat .tin/config
+
+# Remote is configured as:
+# {
+#   "remotes": [{"name": "origin", "url": "..."}],
+#   "code_host_url": "https://github.com/...",
+#   "thread_host_url": "..."
+# }
+```
+
+## Why Not Fall Back to Git?
+
+When tin fails, always fix it rather than using git directly:
+
+1. **Breaks conversation linking** - PR reviewers lose context on why changes were made
+2. **Incomplete history** - Team's searchable AI decision history becomes incomplete
+3. **Quick fixes** - Most tin issues resolve in 30 seconds with `tin sync` or `tin init`
+
+The conversation context is valuable for code review and debugging - don't lose it by falling back to raw git.

--- a/skills/tin/SKILL.md
+++ b/skills/tin/SKILL.md
@@ -1,0 +1,78 @@
+---
+name: tin
+description: Use tin instead of git for commits, checkouts, and pushes. Tin links conversation threads to commits for code review context. Activate when committing code, switching branches, pushing changes, or any git version control operations.
+---
+
+# Tin: Conversation-Linked Version Control
+
+Tin wraps git to link AI conversation threads to commits. This gives PR reviewers full context on why changes were made.
+
+## CRITICAL RULES
+
+**NEVER use these git commands directly:**
+
+| Instead of | Use |
+|------------|-----|
+| `git commit` | `tin commit -m "msg"` or `/tin:commit` |
+| `git checkout` | `tin checkout <branch>` or `/tin:checkout` |
+| `git push` | `tin push` |
+
+Breaking these rules breaks conversation linking that teams rely on for code review.
+
+## Why Tin?
+
+- Commit messages auto-include links to this conversation
+- PR reviewers can see full AI decision context
+- Team has searchable history of AI conversations
+
+## Quick Commands
+
+| Action | Command |
+|--------|---------|
+| Commit | `tin commit -m "msg"` or `/tin:commit` |
+| Status | `tin status` |
+| Switch branch | `tin checkout <branch>` or `/tin:checkout` |
+| Create branch | `tin checkout -b <name>` |
+| Push | `tin push` |
+| List branches | `tin branch` or `/tin:branches` |
+| View history | `tin log` |
+
+## Prerequisites
+
+Tin must be installed and the repository initialized:
+
+```bash
+# Install tin (if not already installed)
+go install github.com/sestinj/tin/cmd/tin@latest
+
+# Initialize in a git repo
+tin init
+```
+
+## Common Issues
+
+### Branch mismatch error
+
+```
+error: tin branch 'main' does not match git branch 'feature-branch'
+```
+
+Fix: `tin sync --tin-follows-git`
+
+### Not a tin repository
+
+```
+error: not a tin repository
+```
+
+Fix: `tin init`
+
+### Missing .tin/HEAD
+
+Fix:
+```bash
+echo "main" > .tin/HEAD
+tin sync --tin-follows-git
+```
+
+See REFERENCE.md for full command reference and troubleshooting.


### PR DESCRIPTION
Fixes branch operations for names containing slashes like `feature/foo` or `nate/my-branch`.

  Changes:
  - `WriteBranch`: Create parent directories before writing ref file
  - `ListBranches`: Use `filepath.WalkDir` to find branches in subdirectories

  Tests updated to use `feature/test` branch name.

---

This PR will not dilute the 100% vibe-codedness of `tin`. If there are any guidelines you have in mind (e.g. maybe I should commit with `tin`) let me know!